### PR TITLE
Change per SW551825

### DIFF
--- a/Rainier-2U-MRW.xml
+++ b/Rainier-2U-MRW.xml
@@ -2964,6 +2964,10 @@
 		<value>0x0</value>
 		</enumerator>
 		<enumerator>
+		<name>SKIP_FIRST_LOAD</name>
+		<value>0x3</value>
+		</enumerator>
+		<enumerator>
 		<name>DO_NOT_LOAD</name>
 		<value>0x2</value>
 		</enumerator>
@@ -3170,6 +3174,17 @@
 		<enumerator>
 		<name>2_BYTE</name>
 		<value>1</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>PROC_FAVOR_AGGRESSIVE_PREFETCH</id>
+		<enumerator>
+		<name>TRUE</name>
+		<value>1</value>
+		</enumerator>
+		<enumerator>
+		<name>FALSE</name>
+		<value>0</value>
 		</enumerator>
 </enumerationType>
 <enumerationType>
@@ -40350,6 +40365,13 @@
 	</property>
 </globalSetting>
 <globalSetting>
+	<id>/sys-0/node-0/nisqually-0/vdd-vrm-connector-0/vdd-vrm-0/avs-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
 	<id>/sys-0/node-0/nisqually-0/vdd-vrm-connector-0/vdd-vrm-0/generic-logic-assoc</id>
 	<property>
 	<id>ASSOCIATION_TYPE</id>
@@ -40358,13 +40380,6 @@
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/nisqually-0/vdd-vrm-connector-0/vdd-vrm-0/avs-slave</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
 	</property>
 </globalSetting>
 <globalSetting>
@@ -40455,13 +40470,6 @@
 	<property>
 	<id>FRU_ID</id>
 	<value>0</value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/nisqually-0/vdd-vrm-connector-0/vdd-vrm-0/avs-slave</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
 	</property>
 </globalSetting>
 <globalSetting>
@@ -40577,6 +40585,13 @@
 	</property>
 </globalSetting>
 <globalSetting>
+	<id>/sys-0/node-0/nisqually-0/vdd-vrm-connector-1/vdd-vrm-0/avs-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
 	<id>/sys-0/node-0/nisqually-0/vdd-vrm-connector-1/vdd-vrm-0/generic-logic-assoc</id>
 	<property>
 	<id>ASSOCIATION_TYPE</id>
@@ -40592,13 +40607,6 @@
 	<property>
 	<id>FRU_ID</id>
 	<value>0</value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/nisqually-0/vdd-vrm-connector-1/vdd-vrm-0/avs-slave</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
 	</property>
 </globalSetting>
 <globalSetting>
@@ -40689,13 +40697,6 @@
 	<property>
 	<id>FRU_ID</id>
 	<value>0</value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/nisqually-0/vdd-vrm-connector-1/vdd-vrm-0/avs-slave</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
 	</property>
 </globalSetting>
 <globalSetting>
@@ -42598,10 +42599,6 @@
 		<default>0x00</default>
 	</attribute>
 	<attribute>
-		<id>PLDM_CONNECTOR_PDRS_ENABLED</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
 		<id>PMIC_ERROR_TEMP_DEG_C</id>
 		<default>80</default>
 	</attribute>
@@ -42636,6 +42633,10 @@
 	<attribute>
 		<id>PROC_FABRIC_TOPOLOGY_MODE</id>
 		<default>MODE0</default>
+	</attribute>
+	<attribute>
+		<id>PROC_FAVOR_AGGRESSIVE_PREFETCH</id>
+		<default></default>
 	</attribute>
 	<attribute>
 		<id>PROC_IO_READ_TIMEOUT_SEC</id>
@@ -127237,7 +127238,7 @@
 	<child_id>vdd-vrm-vpd-0</child_id>
 	<child_id>vdd-0</child_id>
 	<child_id>vdd-1</child_id>
-   <child_id>avs-slave</child_id>
+	<child_id>avs-slave</child_id>
 	<attribute>
 		<id>CARD_TYPE</id>
 		<default>VRM</default>
@@ -127627,37 +127628,6 @@
 	</attribute>
 </targetInstance>
 <targetInstance>
-	<id>avs-slave</id>
-	<type>unit-avs-slave</type>
-	<is_root>false</is_root>
-	<instance_name>avs-slave</instance_name>
-	<position>-1</position>
-	<attribute>
-		<id>BUS_TYPE</id>
-		<default>AVS</default>
-	</attribute>
-	<attribute>
-		<id>CHIP_UNIT</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>CLASS</id>
-		<default>UNIT</default>
-	</attribute>
-	<attribute>
-		<id>DIRECTION</id>
-		<default>IN</default>
-	</attribute>
-	<attribute>
-		<id>MRW_TYPE</id>
-		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>TYPE</id>
-		<default>NA</default>
-	</attribute>
-</targetInstance>
-<targetInstance>
 	<id>vdd-1</id>
 	<type>chip-vrd-i2c</type>
 	<is_root>false</is_root>
@@ -127718,6 +127688,37 @@
 	<attribute>
 		<id>TYPE</id>
 		<default></default>
+	</attribute>
+</targetInstance>
+<targetInstance>
+	<id>avs-slave</id>
+	<type>unit-avs-slave</type>
+	<is_root>false</is_root>
+	<instance_name>avs-slave</instance_name>
+	<position>-1</position>
+	<attribute>
+		<id>BUS_TYPE</id>
+		<default>AVS</default>
+	</attribute>
+	<attribute>
+		<id>CHIP_UNIT</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>UNIT</default>
+	</attribute>
+	<attribute>
+		<id>DIRECTION</id>
+		<default>IN</default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
 	</attribute>
 </targetInstance>
 <targetInstance>
@@ -146230,10 +146231,6 @@
 	<instance_name>TMP435-i2c</instance_name>
 	<position>-1</position>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>I2C</default>
 	</attribute>
@@ -146250,28 +146247,12 @@
 		<default>IN</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
 		<id>I2C_ADDRESS</id>
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MODEL</id>
-		<default>POWER10</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>PHYS_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>RESOURCE_IS_CRITICAL</id>
-		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>

--- a/Rainier-2U-MRW.xml
+++ b/Rainier-2U-MRW.xml
@@ -3184,6 +3184,21 @@
 		</enumerator>
 </enumerationType>
 <enumerationType>
+	<id>PROC_LCO_MODE_SETUP</id>
+		<enumerator>
+		<name>ALL</name>
+		<value>1</value>
+		</enumerator>
+		<enumerator>
+		<name>ADAPTIVE</name>
+		<value>0</value>
+		</enumerator>
+		<enumerator>
+		<name>ECO_ONLY</name>
+		<value>2</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
 	<id>PROC_MODULE_TYPE</id>
 		<enumerator>
 		<name>BLAISE</name>
@@ -4640,6 +4655,10 @@
 	<property>
 	<id>FRU_ID</id>
 	<value>0</value>
+	</property>
+	<property>
+	<id>PROC_FABRIC_TOPOLOGY_MODE</id>
+	<value></value>
 	</property>
 	<property>
 	<id>RESOURCE_IS_CRITICAL</id>
@@ -40342,6 +40361,13 @@
 	</property>
 </globalSetting>
 <globalSetting>
+	<id>/sys-0/node-0/nisqually-0/vdd-vrm-connector-0/vdd-vrm-0/vdd-0/avs-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
 	<id>/sys-0/node-0/nisqually-0/vdd-vrm-connector-0/vdd-vrm-0/vdd-0/vrd-i2c.enable</id>
 	<property>
 	<id>DIRECTION</id>
@@ -40429,6 +40455,13 @@
 	<property>
 	<id>FRU_ID</id>
 	<value>0</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/vdd-vrm-connector-0/vdd-vrm-0/vdd-1/avs-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
 	</property>
 </globalSetting>
 <globalSetting>
@@ -40562,6 +40595,13 @@
 	</property>
 </globalSetting>
 <globalSetting>
+	<id>/sys-0/node-0/nisqually-0/vdd-vrm-connector-1/vdd-vrm-0/vdd-0/avs-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
 	<id>/sys-0/node-0/nisqually-0/vdd-vrm-connector-1/vdd-vrm-0/vdd-0/vrd-i2c.enable</id>
 	<property>
 	<id>DIRECTION</id>
@@ -40649,6 +40689,13 @@
 	<property>
 	<id>FRU_ID</id>
 	<value>0</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/vdd-vrm-connector-1/vdd-vrm-0/vdd-1/avs-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
 	</property>
 </globalSetting>
 <globalSetting>
@@ -40757,6 +40804,13 @@
 	</property>
 	<property>
 	<id>RESOURCE_IS_CRITICAL</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/vdn-vcs-0/avs-slave</id>
+	<property>
+	<id>DIRECTION</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -40958,6 +41012,13 @@
 	</property>
 </globalSetting>
 <globalSetting>
+	<id>/sys-0/node-0/nisqually-0/vdn-vcs-1/avs-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
 	<id>/sys-0/node-0/nisqually-0/vdn-vcs-1/vrd-i2c-2.enable</id>
 	<property>
 	<id>DIRECTION</id>
@@ -41155,6 +41216,13 @@
 	</property>
 </globalSetting>
 <globalSetting>
+	<id>/sys-0/node-0/nisqually-0/vio-vcs-0/avs-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
 	<id>/sys-0/node-0/nisqually-0/vio-vcs-0/vrd-i2c-2.enable</id>
 	<property>
 	<id>DIRECTION</id>
@@ -41348,6 +41416,13 @@
 	</property>
 	<property>
 	<id>RESOURCE_IS_CRITICAL</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/vio-vcs-1/avs-slave</id>
+	<property>
+	<id>DIRECTION</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -42571,6 +42646,18 @@
 		<default></default>
 	</attribute>
 	<attribute>
+		<id>PROC_LCO_MODE_SETUP</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>PROC_LCO_MODE_SETUP_ADAPTIVE_D</id>
+		<default>1000</default>
+	</attribute>
+	<attribute>
+		<id>PROC_LCO_MODE_SETUP_ADAPTIVE_N</id>
+		<default>333</default>
+	</attribute>
+	<attribute>
 		<id>PROC_MODULE_TYPE</id>
 		<default>GODEL</default>
 	</attribute>
@@ -43113,6 +43200,174 @@
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
+	<bus>
+		<bus_id>proc_socket-0/godel-0/power10-0/avs0-master => vdd-vrm-connector-0/vdd-vrm-0/vdd-0/avs-slave</bus_id>
+		<bus_type>AVS</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-0/godel-0/power10-0/</source_path>
+		<source_target>avs0-master</source_target>
+		<dest_path>vdd-vrm-connector-0/vdd-vrm-0/vdd-0/</dest_path>
+		<dest_target>avs-slave</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/vdd-vrm-connector-0/vdd-vrm-0,L:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-0/godel-0/power10-0/avs1-master => vdn-vcs-0/avs-slave</bus_id>
+		<bus_type>AVS</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-0/godel-0/power10-0/</source_path>
+		<source_target>avs1-master</source_target>
+		<dest_path>vdn-vcs-0/</dest_path>
+		<dest_target>avs-slave</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0,L:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-0/godel-0/power10-1/avs0-master => vdd-vrm-connector-0/vdd-vrm-0/vdd-1/avs-slave</bus_id>
+		<bus_type>AVS</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-0/godel-0/power10-1/</source_path>
+		<source_target>avs0-master</source_target>
+		<dest_path>vdd-vrm-connector-0/vdd-vrm-0/vdd-1/</dest_path>
+		<dest_target>avs-slave</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/vdd-vrm-connector-0/vdd-vrm-0,L:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-0/godel-0/power10-1/avs1-master => vio-vcs-0/avs-slave</bus_id>
+		<bus_type>AVS</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-0/godel-0/power10-1/</source_path>
+		<source_target>avs1-master</source_target>
+		<dest_path>vio-vcs-0/</dest_path>
+		<dest_target>avs-slave</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0,L:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-1/godel-0/power10-0/avs0-master => vdd-vrm-connector-1/vdd-vrm-0/vdd-0/avs-slave</bus_id>
+		<bus_type>AVS</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-1/godel-0/power10-0/</source_path>
+		<source_target>avs0-master</source_target>
+		<dest_path>vdd-vrm-connector-1/vdd-vrm-0/vdd-0/</dest_path>
+		<dest_target>avs-slave</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/vdd-vrm-connector-1/vdd-vrm-0,L:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-1/godel-0/power10-0/avs1-master => vdn-vcs-1/avs-slave</bus_id>
+		<bus_type>AVS</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-1/godel-0/power10-0/</source_path>
+		<source_target>avs1-master</source_target>
+		<dest_path>vdn-vcs-1/</dest_path>
+		<dest_target>avs-slave</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0,L:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-1/godel-0/power10-1/avs0-master => vdd-vrm-connector-1/vdd-vrm-0/vdd-1/avs-slave</bus_id>
+		<bus_type>AVS</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-1/godel-0/power10-1/</source_path>
+		<source_target>avs0-master</source_target>
+		<dest_path>vdd-vrm-connector-1/vdd-vrm-0/vdd-1/</dest_path>
+		<dest_target>avs-slave</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/vdd-vrm-connector-1/vdd-vrm-0,L:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-1/godel-0/power10-1/avs1-master => vio-vcs-1/avs-slave</bus_id>
+		<bus_type>AVS</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-1/godel-0/power10-1/</source_path>
+		<source_target>avs1-master</source_target>
+		<dest_path>vio-vcs-1/</dest_path>
+		<dest_target>avs-slave</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0,L:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+	</bus>
 	<bus>
 		<bus_id>Si5332LD-0/Si5332LD.OUT0 => proc_socket-0/godel-0/power10-0/osc0-sys-refclk</bus_id>
 		<bus_type>CLK</bus_type>
@@ -48529,6 +48784,10 @@
 		<default>L:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/vdd-vrm-connector-0/vdd-vrm-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -48560,6 +48819,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/vdd-vrm-connector-0/vdd-vrm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -48595,6 +48858,10 @@
 		<default>L:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/vdd-vrm-connector-0/vdd-vrm-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -48626,6 +48893,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -48661,6 +48932,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -48692,6 +48967,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -48727,6 +49006,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -48758,6 +49041,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -48793,6 +49080,10 @@
 		<default>L:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/vdd-vrm-connector-1/vdd-vrm-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -48824,6 +49115,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/vdd-vrm-connector-1/vdd-vrm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -48859,6 +49154,10 @@
 		<default>L:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/vdd-vrm-connector-1/vdd-vrm-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -48890,6 +49189,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -48925,6 +49228,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -48956,6 +49263,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -48991,6 +49302,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -49022,6 +49337,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -49057,6 +49376,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -49088,6 +49411,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -49123,6 +49450,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0(ucd90320-0)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -49154,6 +49485,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -49189,6 +49524,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -49220,6 +49559,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -49255,6 +49598,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -49286,6 +49633,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0,L:/sys-0/node-0/nisqually-0/power-distribution-connector-0/emmons-0,H:/sys-0/node-0/nisqually-0/power-distribution-connector-0/emmons-0/power-supply-connector-0/power-supply-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -49321,6 +49672,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0,L:/sys-0/node-0/nisqually-0/power-distribution-connector-0/emmons-0,H:/sys-0/node-0/nisqually-0/power-distribution-connector-0/emmons-0/power-supply-connector-1/power-supply-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -49352,6 +49707,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/base-op-panel-connector-0/blyth-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -49387,6 +49746,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/base-op-panel-connector-0/blyth-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -49418,6 +49781,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/base-op-panel-connector-0/blyth-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -49453,6 +49820,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/base-op-panel-connector-0/blyth-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -49484,6 +49855,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/base-op-panel-connector-0/blyth-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -49519,6 +49894,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/lcd-op-panel-connector-0/russell-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -49550,6 +49929,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/lcd-op-panel-connector-0/russell-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -49585,6 +49968,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/tpm-connector-0/wilson-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -49616,6 +50003,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -49651,6 +50042,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-0/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -49682,6 +50077,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-0/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -49717,6 +50116,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-0/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -49748,6 +50151,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-0/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -49783,6 +50190,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-0/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -49814,6 +50225,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-0/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -49849,6 +50264,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-1/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -49880,6 +50299,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-1/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -49915,6 +50338,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-1/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -49946,6 +50373,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-1/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -49981,6 +50412,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-1/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -50012,6 +50447,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-1/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -50047,6 +50486,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-2/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -50078,6 +50521,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-2/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -50113,6 +50560,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-2/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -50144,6 +50595,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-2/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -50179,6 +50634,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-2/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -50210,6 +50669,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-2/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -50245,6 +50708,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-3/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -50276,6 +50743,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-3/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -50311,6 +50782,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-3/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -50342,6 +50817,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-3/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -50377,6 +50856,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-3/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -50408,6 +50891,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-3/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -50443,6 +50930,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-4/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -50474,6 +50965,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-4/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -50509,6 +51004,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-4/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -50540,6 +51039,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-4/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -50575,6 +51078,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-4/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -50606,6 +51113,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-4/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -50641,6 +51152,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-5/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -50672,6 +51187,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-5/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -50707,6 +51226,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-5/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -50738,6 +51261,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-5/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -50773,6 +51300,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-5/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -50804,6 +51335,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-5/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -50839,6 +51374,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-6/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -50870,6 +51409,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-6/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -50905,6 +51448,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-6/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -50936,6 +51483,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-6/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -50971,6 +51522,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-6/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -51002,6 +51557,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-6/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -51037,6 +51596,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-7/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -51068,6 +51631,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-7/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -51103,6 +51670,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-7/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -51134,6 +51705,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-7/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -51169,6 +51744,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-7/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -51200,6 +51779,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-7/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -51235,6 +51818,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-8/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -51266,6 +51853,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-8/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -51301,6 +51892,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-8/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -51332,6 +51927,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-8/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -51367,6 +51966,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-8/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -51398,6 +52001,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-8/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -51433,6 +52040,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-9/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -51464,6 +52075,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-9/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -51499,6 +52114,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-9/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -51530,6 +52149,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-9/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -51565,6 +52188,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-9/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -51596,6 +52223,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-9/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -51631,6 +52262,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-10/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -51662,6 +52297,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-10/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -51697,6 +52336,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-10/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -51728,6 +52371,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-10/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -51763,6 +52410,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-10/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -51794,6 +52445,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-10/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -51829,6 +52484,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-11/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -51860,6 +52519,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-11/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -51895,6 +52558,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-11/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -51926,6 +52593,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-11/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -51961,6 +52632,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-11/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -51992,6 +52667,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-11/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -52027,6 +52706,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-12/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -52058,6 +52741,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-12/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -52093,6 +52780,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-12/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -52124,6 +52815,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-12/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -52159,6 +52854,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-12/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -52190,6 +52889,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-12/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -52225,6 +52928,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-13/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -52256,6 +52963,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-13/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -52291,6 +53002,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-13/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -52322,6 +53037,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-13/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -52357,6 +53076,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-13/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -52388,6 +53111,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-13/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -52423,6 +53150,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-14/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -52454,6 +53185,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-14/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -52489,6 +53224,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-14/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -52520,6 +53259,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-14/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -52555,6 +53298,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-14/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -52586,6 +53333,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-14/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -52621,6 +53372,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-15/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -52652,6 +53407,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-15/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -52687,6 +53446,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-15/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -52718,6 +53481,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-15/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -52753,6 +53520,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-15/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -52784,6 +53555,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-15/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -52819,6 +53594,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-16/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -52850,6 +53629,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-16/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -52885,6 +53668,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-16/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -52916,6 +53703,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-16/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -52951,6 +53742,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-16/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -52982,6 +53777,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-16/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -53017,6 +53816,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-17/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -53048,6 +53851,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-17/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -53083,6 +53890,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-17/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -53114,6 +53925,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-17/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -53149,6 +53964,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-17/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -53180,6 +53999,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-17/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -53215,6 +54038,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-18/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -53246,6 +54073,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-18/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -53281,6 +54112,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-18/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -53312,6 +54147,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-18/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -53347,6 +54186,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-18/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -53378,6 +54221,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-18/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -53413,6 +54260,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-19/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -53444,6 +54295,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-19/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -53479,6 +54334,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-19/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -53510,6 +54369,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-19/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -53545,6 +54408,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-19/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -53576,6 +54443,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-19/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -53611,6 +54482,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-20/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -53642,6 +54517,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-20/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -53677,6 +54556,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-20/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -53708,6 +54591,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-20/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -53743,6 +54630,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-20/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -53774,6 +54665,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-20/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -53809,6 +54704,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-21/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -53840,6 +54739,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-21/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -53875,6 +54778,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-21/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -53906,6 +54813,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-21/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -53941,6 +54852,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-21/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -53972,6 +54887,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-21/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -54007,6 +54926,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-22/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -54038,6 +54961,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-22/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -54073,6 +55000,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-22/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -54104,6 +55035,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-22/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -54139,6 +55074,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-22/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -54170,6 +55109,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-22/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -54205,6 +55148,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-23/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -54236,6 +55183,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-23/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -54271,6 +55222,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-23/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -54302,6 +55257,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-23/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -54337,6 +55296,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-23/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -54368,6 +55331,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-23/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -54403,6 +55370,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-24/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -54434,6 +55405,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-24/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -54469,6 +55444,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-24/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -54500,6 +55479,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-24/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -54535,6 +55518,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-24/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -54566,6 +55553,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-24/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -54601,6 +55592,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-25/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -54632,6 +55627,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-25/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -54667,6 +55666,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-25/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -54698,6 +55701,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-25/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -54733,6 +55740,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-25/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -54764,6 +55775,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-25/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -54799,6 +55814,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-26/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -54830,6 +55849,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-26/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -54865,6 +55888,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-26/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -54896,6 +55923,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-26/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -54931,6 +55962,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-26/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -54962,6 +55997,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-26/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -54997,6 +56036,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-27/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -55028,6 +56071,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-27/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -55063,6 +56110,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-27/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -55094,6 +56145,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-27/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -55129,6 +56184,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-27/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -55160,6 +56219,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-27/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -55195,6 +56258,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-28/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -55226,6 +56293,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-28/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -55261,6 +56332,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-28/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -55292,6 +56367,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-28/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -55327,6 +56406,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-28/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -55358,6 +56441,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-28/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -55393,6 +56480,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-29/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -55424,6 +56515,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-29/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -55459,6 +56554,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-29/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -55490,6 +56589,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-29/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -55525,6 +56628,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-29/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -55556,6 +56663,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-29/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -55591,6 +56702,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-30/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -55622,6 +56737,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-30/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -55657,6 +56776,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-30/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -55688,6 +56811,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-30/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -55723,6 +56850,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-30/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -55754,6 +56885,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-30/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -55789,6 +56924,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-31/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -55820,6 +56959,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-31/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -55855,6 +56998,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-31/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -55886,6 +57033,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-31/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -55921,6 +57072,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-31/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -55952,6 +57107,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-31/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -55987,6 +57146,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -56018,6 +57181,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -56053,6 +57220,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -56084,6 +57255,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/fan-card-connector-0/paradise-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -56119,6 +57294,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/fan-card-connector-0/paradise-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -56150,6 +57329,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/dasd-card-connector-0/pyramid-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -56185,6 +57368,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/dasd-card-connector-0/pyramid-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -56216,6 +57403,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/dasd-card-connector-0/pyramid-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -56251,6 +57442,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -56282,6 +57477,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -56317,6 +57516,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -56348,6 +57551,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -56383,6 +57590,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -56414,6 +57625,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -56449,6 +57664,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -56480,6 +57699,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -56515,6 +57738,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -56546,6 +57773,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -56581,6 +57812,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -56612,6 +57847,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -56647,6 +57886,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -56678,6 +57921,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -56713,6 +57960,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -56744,6 +57995,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -56779,6 +58034,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -56810,6 +58069,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -56845,6 +58108,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -56876,6 +58143,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -56911,6 +58182,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -56942,6 +58217,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -56977,6 +58256,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -57008,6 +58291,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -57043,6 +58330,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -57074,6 +58365,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -57109,6 +58404,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -57140,6 +58439,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -57175,6 +58478,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -57206,6 +58513,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -57241,6 +58552,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -57272,6 +58587,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -57307,6 +58626,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -57338,6 +58661,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -57373,6 +58700,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -57404,6 +58735,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -57439,6 +58774,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -57470,6 +58809,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -57505,6 +58848,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -57536,6 +58883,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -57571,6 +58922,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -57602,6 +58957,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -57637,6 +58996,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -57668,6 +59031,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -57703,6 +59070,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -57734,6 +59105,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -57769,6 +59144,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -57800,6 +59179,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -57835,6 +59218,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -57866,6 +59253,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -57901,6 +59292,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -57932,6 +59327,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -57967,6 +59366,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -57998,6 +59401,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -58033,6 +59440,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -58064,6 +59475,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -58099,6 +59514,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/tpm-connector-0/wilson-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -58130,6 +59549,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -58165,6 +59588,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -58196,6 +59623,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -58231,6 +59662,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -58262,6 +59697,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -58297,6 +59736,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -58330,6 +59773,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -58361,6 +59808,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -59609,6 +61060,10 @@
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
+		</bus_attribute>
 	</bus>
 	<bus>
 		<bus_id>proc_socket-0/godel-0/power10-0/mc0/mi0/mcc0/omic0/omi1 => ddimm-connector-1/ddimm-0/ocmb/omi</bus_id>
@@ -59621,6 +61076,10 @@
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -59635,6 +61094,10 @@
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
+		</bus_attribute>
 	</bus>
 	<bus>
 		<bus_id>proc_socket-0/godel-0/power10-0/mc0/mi0/mcc1/omic1/omi3 => ddimm-connector-3/ddimm-0/ocmb/omi</bus_id>
@@ -59647,6 +61110,10 @@
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -59661,6 +61128,10 @@
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
+		</bus_attribute>
 	</bus>
 	<bus>
 		<bus_id>proc_socket-0/godel-0/power10-0/mc1/mi1/mcc2/omic2/omi5 => ddimm-connector-5/ddimm-0/ocmb/omi</bus_id>
@@ -59673,6 +61144,10 @@
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -59687,6 +61162,10 @@
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
+		</bus_attribute>
 	</bus>
 	<bus>
 		<bus_id>proc_socket-0/godel-0/power10-0/mc1/mi1/mcc3/omic3/omi7 => ddimm-connector-7/ddimm-0/ocmb/omi</bus_id>
@@ -59699,6 +61178,10 @@
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -59713,6 +61196,10 @@
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
+		</bus_attribute>
 	</bus>
 	<bus>
 		<bus_id>proc_socket-1/godel-0/power10-0/mc0/mi0/mcc0/omic0/omi1 => ddimm-connector-17/ddimm-0/ocmb/omi</bus_id>
@@ -59725,6 +61212,10 @@
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -59739,6 +61230,10 @@
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
+		</bus_attribute>
 	</bus>
 	<bus>
 		<bus_id>proc_socket-1/godel-0/power10-0/mc0/mi0/mcc1/omic1/omi3 => ddimm-connector-19/ddimm-0/ocmb/omi</bus_id>
@@ -59751,6 +61246,10 @@
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -59765,6 +61264,10 @@
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
+		</bus_attribute>
 	</bus>
 	<bus>
 		<bus_id>proc_socket-1/godel-0/power10-0/mc1/mi1/mcc2/omic2/omi5 => ddimm-connector-21/ddimm-0/ocmb/omi</bus_id>
@@ -59777,6 +61280,10 @@
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -59791,6 +61298,10 @@
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
+		</bus_attribute>
 	</bus>
 	<bus>
 		<bus_id>proc_socket-1/godel-0/power10-0/mc1/mi1/mcc3/omic3/omi7 => ddimm-connector-23/ddimm-0/ocmb/omi</bus_id>
@@ -59803,6 +61314,10 @@
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -59817,6 +61332,10 @@
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
+		</bus_attribute>
 	</bus>
 	<bus>
 		<bus_id>proc_socket-0/godel-0/power10-1/mc2/mi2/mcc4/omic4/omi9 => ddimm-connector-9/ddimm-0/ocmb/omi</bus_id>
@@ -59829,6 +61348,10 @@
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -59843,6 +61366,10 @@
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
+		</bus_attribute>
 	</bus>
 	<bus>
 		<bus_id>proc_socket-0/godel-0/power10-1/mc2/mi2/mcc5/omic5/omi11 => ddimm-connector-11/ddimm-0/ocmb/omi</bus_id>
@@ -59855,6 +61382,10 @@
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -59869,6 +61400,10 @@
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
+		</bus_attribute>
 	</bus>
 	<bus>
 		<bus_id>proc_socket-0/godel-0/power10-1/mc3/mi3/mcc6/omic6/omi13 => ddimm-connector-13/ddimm-0/ocmb/omi</bus_id>
@@ -59881,6 +61416,10 @@
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -59895,6 +61434,10 @@
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
+		</bus_attribute>
 	</bus>
 	<bus>
 		<bus_id>proc_socket-0/godel-0/power10-1/mc3/mi3/mcc7/omic7/omi15 => ddimm-connector-15/ddimm-0/ocmb/omi</bus_id>
@@ -59907,6 +61450,10 @@
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -59921,6 +61468,10 @@
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
+		</bus_attribute>
 	</bus>
 	<bus>
 		<bus_id>proc_socket-1/godel-0/power10-1/mc2/mi2/mcc4/omic4/omi9 => ddimm-connector-25/ddimm-0/ocmb/omi</bus_id>
@@ -59933,6 +61484,10 @@
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -59947,6 +61502,10 @@
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
+		</bus_attribute>
 	</bus>
 	<bus>
 		<bus_id>proc_socket-1/godel-0/power10-1/mc2/mi2/mcc5/omic5/omi11 => ddimm-connector-27/ddimm-0/ocmb/omi</bus_id>
@@ -59959,6 +61518,10 @@
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -59973,6 +61536,10 @@
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
+		</bus_attribute>
 	</bus>
 	<bus>
 		<bus_id>proc_socket-1/godel-0/power10-1/mc3/mi3/mcc6/omic6/omi13 => ddimm-connector-29/ddimm-0/ocmb/omi</bus_id>
@@ -59985,6 +61552,10 @@
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -59999,6 +61570,10 @@
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
+		</bus_attribute>
 	</bus>
 	<bus>
 		<bus_id>proc_socket-1/godel-0/power10-1/mc3/mi3/mcc7/omic7/omi15 => ddimm-connector-31/ddimm-0/ocmb/omi</bus_id>
@@ -60011,6 +61586,10 @@
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -79541,6 +81120,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -79574,6 +81157,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -79605,6 +81192,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -125747,6 +127338,7 @@
 	<child_id>vrd-i2c.enable</child_id>
 	<child_id>vrd-i2c.vin</child_id>
 	<child_id>vrd-i2c.vout</child_id>
+	<child_id>avs-slave</child_id>
 	<attribute>
 		<id>AFFINITY_PATH</id>
 		<default></default>
@@ -126035,6 +127627,37 @@
 	</attribute>
 </targetInstance>
 <targetInstance>
+	<id>avs-slave</id>
+	<type>unit-avs-slave</type>
+	<is_root>false</is_root>
+	<instance_name>avs-slave</instance_name>
+	<position>-1</position>
+	<attribute>
+		<id>BUS_TYPE</id>
+		<default>AVS</default>
+	</attribute>
+	<attribute>
+		<id>CHIP_UNIT</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>UNIT</default>
+	</attribute>
+	<attribute>
+		<id>DIRECTION</id>
+		<default>IN</default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetInstance>
+<targetInstance>
 	<id>vdd-1</id>
 	<type>chip-vrd-i2c</type>
 	<is_root>false</is_root>
@@ -126045,6 +127668,7 @@
 	<child_id>vrd-i2c.enable</child_id>
 	<child_id>vrd-i2c.vin</child_id>
 	<child_id>vrd-i2c.vout</child_id>
+	<child_id>avs-slave</child_id>
 	<attribute>
 		<id>AFFINITY_PATH</id>
 		<default></default>
@@ -126273,6 +127897,7 @@
 	<child_id>vrd-i2c-2.vin</child_id>
 	<child_id>vrd-i2c-2.vout1</child_id>
 	<child_id>vrd-i2c-2.vout2</child_id>
+	<child_id>avs-slave</child_id>
 	<attribute>
 		<id>AFFINITY_PATH</id>
 		<default></default>
@@ -126735,6 +128360,7 @@
 	<child_id>vrd-i2c-2.vin</child_id>
 	<child_id>vrd-i2c-2.vout1</child_id>
 	<child_id>vrd-i2c-2.vout2</child_id>
+	<child_id>avs-slave</child_id>
 	<attribute>
 		<id>AFFINITY_PATH</id>
 		<default></default>
@@ -126801,6 +128427,7 @@
 	<child_id>vrd-i2c-2.vin</child_id>
 	<child_id>vrd-i2c-2.vout1</child_id>
 	<child_id>vrd-i2c-2.vout2</child_id>
+	<child_id>avs-slave</child_id>
 	<attribute>
 		<id>AFFINITY_PATH</id>
 		<default></default>
@@ -126867,6 +128494,7 @@
 	<child_id>vrd-i2c-2.vin</child_id>
 	<child_id>vrd-i2c-2.vout1</child_id>
 	<child_id>vrd-i2c-2.vout2</child_id>
+	<child_id>avs-slave</child_id>
 	<attribute>
 		<id>AFFINITY_PATH</id>
 		<default></default>
@@ -143710,6 +145338,7 @@
 	<child_id>cablecard-LED-CXP-TOP</child_id>
 	<child_id>cablecard-LED-CXP-BOT</child_id>
 	<child_id>i2c-slave</child_id>
+	<child_id>cablecard-TMP435</child_id>
 	<attribute>
 		<id>AFFINITY_PATH</id>
 		<default></default>
@@ -144549,6 +146178,109 @@
 	<attribute>
 		<id>VIEW_REAR</id>
 		<default>YES</default>
+	</attribute>
+</targetInstance>
+<targetInstance>
+	<id>cablecard-TMP435</id>
+	<type>chip-tmp-device</type>
+	<is_root>false</is_root>
+	<instance_name>cablecard-TMP435</instance_name>
+	<position>-1</position>
+	<child_id>TMP435-i2c</child_id>
+	<attribute>
+		<id>CLASS</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>COOLING_ZONE_MASK</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>I2C_ADDRESS</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>I2C_SPEED</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>TMP</default>
+	</attribute>
+	<attribute>
+		<id>POSITION</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>RU_TYPE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>TARGET-FRU-TYPE</id>
+		<default>planar</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetInstance>
+<targetInstance>
+	<id>TMP435-i2c</id>
+	<type>unit-i2c-slave</type>
+	<is_root>false</is_root>
+	<instance_name>TMP435-i2c</instance_name>
+	<position>-1</position>
+	<attribute>
+		<id>AFFINITY_PATH</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>BUS_TYPE</id>
+		<default>I2C</default>
+	</attribute>
+	<attribute>
+		<id>CHIP_UNIT</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>UNIT</default>
+	</attribute>
+	<attribute>
+		<id>DIRECTION</id>
+		<default>IN</default>
+	</attribute>
+	<attribute>
+		<id>FAPI_NAME</id>
+		<default>unknown</default>
+	</attribute>
+	<attribute>
+		<id>I2C_ADDRESS</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>MODEL</id>
+		<default>POWER10</default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>PHYS_PATH</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>VPD_SIZE</id>
+		<default>NA</default>
 	</attribute>
 </targetInstance>
 <targetInstance>

--- a/Rainier-2U-MRW.xml
+++ b/Rainier-2U-MRW.xml
@@ -40361,7 +40361,7 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/vdd-vrm-connector-0/vdd-vrm-0/vdd-0/avs-slave</id>
+	<id>/sys-0/node-0/nisqually-0/vdd-vrm-connector-0/vdd-vrm-0/avs-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value></value>
@@ -40458,7 +40458,7 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/vdd-vrm-connector-0/vdd-vrm-0/vdd-1/avs-slave</id>
+	<id>/sys-0/node-0/nisqually-0/vdd-vrm-connector-0/vdd-vrm-0/avs-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value></value>
@@ -40595,7 +40595,7 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/vdd-vrm-connector-1/vdd-vrm-0/vdd-0/avs-slave</id>
+	<id>/sys-0/node-0/nisqually-0/vdd-vrm-connector-1/vdd-vrm-0/avs-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value></value>
@@ -40692,7 +40692,7 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/vdd-vrm-connector-1/vdd-vrm-0/vdd-1/avs-slave</id>
+	<id>/sys-0/node-0/nisqually-0/vdd-vrm-connector-1/vdd-vrm-0/avs-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value></value>
@@ -43201,12 +43201,12 @@
 		<default>NA</default>
 	</attribute>
 	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-0/avs0-master => vdd-vrm-connector-0/vdd-vrm-0/vdd-0/avs-slave</bus_id>
+		<bus_id>proc_socket-0/godel-0/power10-0/avs0-master => vdd-vrm-connector-0/vdd-vrm-0/avs-slave</bus_id>
 		<bus_type>AVS</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-0/godel-0/power10-0/</source_path>
 		<source_target>avs0-master</source_target>
-		<dest_path>vdd-vrm-connector-0/vdd-vrm-0/vdd-0/</dest_path>
+		<dest_path>vdd-vrm-connector-0/vdd-vrm-0/</dest_path>
 		<dest_target>avs-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
@@ -43243,12 +43243,12 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-1/avs0-master => vdd-vrm-connector-0/vdd-vrm-0/vdd-1/avs-slave</bus_id>
+		<bus_id>proc_socket-0/godel-0/power10-1/avs0-master => vdd-vrm-connector-0/vdd-vrm-0/avs-slave</bus_id>
 		<bus_type>AVS</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-0/godel-0/power10-1/</source_path>
 		<source_target>avs0-master</source_target>
-		<dest_path>vdd-vrm-connector-0/vdd-vrm-0/vdd-1/</dest_path>
+		<dest_path>vdd-vrm-connector-0/vdd-vrm-0/</dest_path>
 		<dest_target>avs-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
@@ -43285,12 +43285,12 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-0/avs0-master => vdd-vrm-connector-1/vdd-vrm-0/vdd-0/avs-slave</bus_id>
+		<bus_id>proc_socket-1/godel-0/power10-0/avs0-master => vdd-vrm-connector-1/vdd-vrm-0/avs-slave</bus_id>
 		<bus_type>AVS</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-1/godel-0/power10-0/</source_path>
 		<source_target>avs0-master</source_target>
-		<dest_path>vdd-vrm-connector-1/vdd-vrm-0/vdd-0/</dest_path>
+		<dest_path>vdd-vrm-connector-1/vdd-vrm-0/</dest_path>
 		<dest_target>avs-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
@@ -43327,12 +43327,12 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-1/avs0-master => vdd-vrm-connector-1/vdd-vrm-0/vdd-1/avs-slave</bus_id>
+		<bus_id>proc_socket-1/godel-0/power10-1/avs0-master => vdd-vrm-connector-1/vdd-vrm-0/avs-slave</bus_id>
 		<bus_type>AVS</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-1/godel-0/power10-1/</source_path>
 		<source_target>avs0-master</source_target>
-		<dest_path>vdd-vrm-connector-1/vdd-vrm-0/vdd-1/</dest_path>
+		<dest_path>vdd-vrm-connector-1/vdd-vrm-0/</dest_path>
 		<dest_target>avs-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
@@ -127237,6 +127237,7 @@
 	<child_id>vdd-vrm-vpd-0</child_id>
 	<child_id>vdd-0</child_id>
 	<child_id>vdd-1</child_id>
+   <child_id>avs-slave</child_id>
 	<attribute>
 		<id>CARD_TYPE</id>
 		<default>VRM</default>
@@ -127338,7 +127339,6 @@
 	<child_id>vrd-i2c.enable</child_id>
 	<child_id>vrd-i2c.vin</child_id>
 	<child_id>vrd-i2c.vout</child_id>
-	<child_id>avs-slave</child_id>
 	<attribute>
 		<id>AFFINITY_PATH</id>
 		<default></default>
@@ -127668,7 +127668,6 @@
 	<child_id>vrd-i2c.enable</child_id>
 	<child_id>vrd-i2c.vin</child_id>
 	<child_id>vrd-i2c.vout</child_id>
-	<child_id>avs-slave</child_id>
 	<attribute>
 		<id>AFFINITY_PATH</id>
 		<default></default>

--- a/Rainier-4U-MRW.xml
+++ b/Rainier-4U-MRW.xml
@@ -3184,6 +3184,21 @@
 		</enumerator>
 </enumerationType>
 <enumerationType>
+	<id>PROC_LCO_MODE_SETUP</id>
+		<enumerator>
+		<name>ALL</name>
+		<value>1</value>
+		</enumerator>
+		<enumerator>
+		<name>ADAPTIVE</name>
+		<value>0</value>
+		</enumerator>
+		<enumerator>
+		<name>ECO_ONLY</name>
+		<value>2</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
 	<id>PROC_MODULE_TYPE</id>
 		<enumerator>
 		<name>BLAISE</name>
@@ -48403,6 +48418,13 @@
 	</property>
 </globalSetting>
 <globalSetting>
+	<id>/sys-0/node-0/nisqually-0/vdd-vrm-connector-0/vdd-vrm-0/vdd-0/avs-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
 	<id>/sys-0/node-0/nisqually-0/vdd-vrm-connector-0/vdd-vrm-0/vdd-0/vrd-i2c.enable</id>
 	<property>
 	<id>DIRECTION</id>
@@ -48490,6 +48512,13 @@
 	<property>
 	<id>FRU_ID</id>
 	<value>0</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/vdd-vrm-connector-0/vdd-vrm-0/vdd-1/avs-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
 	</property>
 </globalSetting>
 <globalSetting>
@@ -48623,6 +48652,13 @@
 	</property>
 </globalSetting>
 <globalSetting>
+	<id>/sys-0/node-0/nisqually-0/vdd-vrm-connector-1/vdd-vrm-0/vdd-0/avs-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
 	<id>/sys-0/node-0/nisqually-0/vdd-vrm-connector-1/vdd-vrm-0/vdd-0/vrd-i2c.enable</id>
 	<property>
 	<id>DIRECTION</id>
@@ -48702,6 +48738,13 @@
 	</property>
 	<property>
 	<id>RAIL_NAME</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/vdd-vrm-connector-1/vdd-vrm-0/vdd-1/avs-slave</id>
+	<property>
+	<id>DIRECTION</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -48811,6 +48854,13 @@
 	</property>
 	<property>
 	<id>RESOURCE_IS_CRITICAL</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/vdn-vcs-0/avs-slave</id>
+	<property>
+	<id>DIRECTION</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -49012,6 +49062,13 @@
 	</property>
 </globalSetting>
 <globalSetting>
+	<id>/sys-0/node-0/nisqually-0/vdn-vcs-1/avs-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
 	<id>/sys-0/node-0/nisqually-0/vdn-vcs-1/vrd-i2c-2.enable</id>
 	<property>
 	<id>DIRECTION</id>
@@ -49209,6 +49266,13 @@
 	</property>
 </globalSetting>
 <globalSetting>
+	<id>/sys-0/node-0/nisqually-0/vio-vcs-0/avs-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
 	<id>/sys-0/node-0/nisqually-0/vio-vcs-0/vrd-i2c-2.enable</id>
 	<property>
 	<id>DIRECTION</id>
@@ -49402,6 +49466,13 @@
 	</property>
 	<property>
 	<id>RESOURCE_IS_CRITICAL</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/vio-vcs-1/avs-slave</id>
+	<property>
+	<id>DIRECTION</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -50625,6 +50696,18 @@
 		<default></default>
 	</attribute>
 	<attribute>
+		<id>PROC_LCO_MODE_SETUP</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>PROC_LCO_MODE_SETUP_ADAPTIVE_D</id>
+		<default>1000</default>
+	</attribute>
+	<attribute>
+		<id>PROC_LCO_MODE_SETUP_ADAPTIVE_N</id>
+		<default>333</default>
+	</attribute>
+	<attribute>
 		<id>PROC_MODULE_TYPE</id>
 		<default>GODEL</default>
 	</attribute>
@@ -51167,6 +51250,174 @@
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
+	<bus>
+		<bus_id>proc_socket-0/godel-0/power10-0/avs0-master => vdd-vrm-connector-0/vdd-vrm-0/vdd-0/avs-slave</bus_id>
+		<bus_type>AVS</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-0/godel-0/power10-0/</source_path>
+		<source_target>avs0-master</source_target>
+		<dest_path>vdd-vrm-connector-0/vdd-vrm-0/vdd-0/</dest_path>
+		<dest_target>avs-slave</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/vdd-vrm-connector-0/vdd-vrm-0,L:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-0/godel-0/power10-0/avs1-master => vdn-vcs-0/avs-slave</bus_id>
+		<bus_type>AVS</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-0/godel-0/power10-0/</source_path>
+		<source_target>avs1-master</source_target>
+		<dest_path>vdn-vcs-0/</dest_path>
+		<dest_target>avs-slave</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0,L:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-0/godel-0/power10-1/avs0-master => vdd-vrm-connector-0/vdd-vrm-0/vdd-1/avs-slave</bus_id>
+		<bus_type>AVS</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-0/godel-0/power10-1/</source_path>
+		<source_target>avs0-master</source_target>
+		<dest_path>vdd-vrm-connector-0/vdd-vrm-0/vdd-1/</dest_path>
+		<dest_target>avs-slave</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/vdd-vrm-connector-0/vdd-vrm-0,L:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-0/godel-0/power10-1/avs1-master => vio-vcs-0/avs-slave</bus_id>
+		<bus_type>AVS</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-0/godel-0/power10-1/</source_path>
+		<source_target>avs1-master</source_target>
+		<dest_path>vio-vcs-0/</dest_path>
+		<dest_target>avs-slave</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0,L:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-1/godel-0/power10-0/avs0-master => vdd-vrm-connector-1/vdd-vrm-0/vdd-0/avs-slave</bus_id>
+		<bus_type>AVS</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-1/godel-0/power10-0/</source_path>
+		<source_target>avs0-master</source_target>
+		<dest_path>vdd-vrm-connector-1/vdd-vrm-0/vdd-0/</dest_path>
+		<dest_target>avs-slave</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/vdd-vrm-connector-1/vdd-vrm-0,L:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-1/godel-0/power10-0/avs1-master => vdn-vcs-1/avs-slave</bus_id>
+		<bus_type>AVS</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-1/godel-0/power10-0/</source_path>
+		<source_target>avs1-master</source_target>
+		<dest_path>vdn-vcs-1/</dest_path>
+		<dest_target>avs-slave</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0,L:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-1/godel-0/power10-1/avs0-master => vdd-vrm-connector-1/vdd-vrm-0/vdd-1/avs-slave</bus_id>
+		<bus_type>AVS</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-1/godel-0/power10-1/</source_path>
+		<source_target>avs0-master</source_target>
+		<dest_path>vdd-vrm-connector-1/vdd-vrm-0/vdd-1/</dest_path>
+		<dest_target>avs-slave</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/vdd-vrm-connector-1/vdd-vrm-0,L:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-1/godel-0/power10-1/avs1-master => vio-vcs-1/avs-slave</bus_id>
+		<bus_type>AVS</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-1/godel-0/power10-1/</source_path>
+		<source_target>avs1-master</source_target>
+		<dest_path>vio-vcs-1/</dest_path>
+		<dest_target>avs-slave</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0,L:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+	</bus>
 	<bus>
 		<bus_id>Si5332LD-0/Si5332LD.OUT0 => proc_socket-0/godel-0/power10-0/osc0-sys-refclk</bus_id>
 		<bus_type>CLK</bus_type>
@@ -56835,6 +57086,10 @@
 		<default>L:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/vdd-vrm-connector-0/vdd-vrm-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -56866,6 +57121,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/vdd-vrm-connector-0/vdd-vrm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -56901,6 +57160,10 @@
 		<default>L:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/vdd-vrm-connector-0/vdd-vrm-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -56932,6 +57195,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -56967,6 +57234,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -56998,6 +57269,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -57033,6 +57308,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -57064,6 +57343,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -57099,6 +57382,10 @@
 		<default>L:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/vdd-vrm-connector-1/vdd-vrm-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -57130,6 +57417,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/vdd-vrm-connector-1/vdd-vrm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -57165,6 +57456,10 @@
 		<default>L:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/vdd-vrm-connector-1/vdd-vrm-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -57196,6 +57491,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -57231,6 +57530,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -57262,6 +57565,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -57297,6 +57604,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -57328,6 +57639,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -57363,6 +57678,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -57394,6 +57713,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -57429,6 +57752,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0(ucd90320-0)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -57460,6 +57787,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -57495,6 +57826,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -57526,6 +57861,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -57561,6 +57900,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -57592,6 +57935,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0,L:/sys-0/node-0/nisqually-0/power-distribution-connector-0/fryingpan-0,H:/sys-0/node-0/nisqually-0/power-distribution-connector-0/fryingpan-0/power-supply-connector-0/power-supply-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -57627,6 +57974,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0,L:/sys-0/node-0/nisqually-0/power-distribution-connector-0/fryingpan-0,H:/sys-0/node-0/nisqually-0/power-distribution-connector-0/fryingpan-0/power-supply-connector-1/power-supply-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -57658,6 +58009,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0,L:/sys-0/node-0/nisqually-0/power-distribution-connector-0/fryingpan-0,H:/sys-0/node-0/nisqually-0/power-distribution-connector-0/fryingpan-0/power-supply-connector-2/power-supply-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -57693,6 +58048,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0,L:/sys-0/node-0/nisqually-0/power-distribution-connector-0/fryingpan-0,H:/sys-0/node-0/nisqually-0/power-distribution-connector-0/fryingpan-0/power-supply-connector-3/power-supply-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -57724,6 +58083,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/base-op-panel-connector-0/blyth-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -57759,6 +58122,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/base-op-panel-connector-0/blyth-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -57790,6 +58157,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/base-op-panel-connector-0/blyth-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -57825,6 +58196,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/base-op-panel-connector-0/blyth-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -57856,6 +58231,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/base-op-panel-connector-0/blyth-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -57891,6 +58270,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/lcd-op-panel-connector-0/russell-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -57922,6 +58305,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/lcd-op-panel-connector-0/russell-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -57957,6 +58344,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/tpm-connector-0/wilson-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -57988,6 +58379,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -58023,6 +58418,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-0/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -58054,6 +58453,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-0/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -58089,6 +58492,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-0/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -58120,6 +58527,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-0/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -58155,6 +58566,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-0/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -58186,6 +58601,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-1/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -58221,6 +58640,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-1/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -58252,6 +58675,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-1/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -58287,6 +58714,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-1/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -58318,6 +58749,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-1/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -58353,6 +58788,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-2/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -58384,6 +58823,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-2/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -58419,6 +58862,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-2/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -58450,6 +58897,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-2/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -58485,6 +58936,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-2/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -58516,6 +58971,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-3/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -58551,6 +59010,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-3/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -58582,6 +59045,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-3/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -58617,6 +59084,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-3/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -58648,6 +59119,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-3/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -58683,6 +59158,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-4/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -58714,6 +59193,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-4/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -58749,6 +59232,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-4/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -58780,6 +59267,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-4/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -58815,6 +59306,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-4/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -58846,6 +59341,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-5/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -58881,6 +59380,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-5/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -58912,6 +59415,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-5/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -58947,6 +59454,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-5/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -58978,6 +59489,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-5/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -59013,6 +59528,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-6/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -59044,6 +59563,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-6/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -59079,6 +59602,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-6/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -59110,6 +59637,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-6/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -59145,6 +59676,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-6/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -59176,6 +59711,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-7/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -59211,6 +59750,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-7/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -59242,6 +59785,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-7/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -59277,6 +59824,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-7/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -59308,6 +59859,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-7/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -59343,6 +59898,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-8/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -59374,6 +59933,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-8/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -59409,6 +59972,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-8/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -59440,6 +60007,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-8/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -59475,6 +60046,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-8/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -59506,6 +60081,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-9/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -59541,6 +60120,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-9/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -59572,6 +60155,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-9/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -59607,6 +60194,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-9/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -59638,6 +60229,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-9/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -59673,6 +60268,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-10/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -59704,6 +60303,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-10/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -59739,6 +60342,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-10/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -59770,6 +60377,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-10/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -59805,6 +60416,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-10/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -59836,6 +60451,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-11/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -59871,6 +60490,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-11/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -59902,6 +60525,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-11/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -59937,6 +60564,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-11/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -59968,6 +60599,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-11/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -60003,6 +60638,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-12/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -60034,6 +60673,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-12/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -60069,6 +60712,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-12/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -60100,6 +60747,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-12/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -60135,6 +60786,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-12/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -60166,6 +60821,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-13/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -60201,6 +60860,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-13/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -60232,6 +60895,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-13/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -60267,6 +60934,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-13/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -60298,6 +60969,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-13/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -60333,6 +61008,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-14/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -60364,6 +61043,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-14/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -60399,6 +61082,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-14/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -60430,6 +61117,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-14/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -60465,6 +61156,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-14/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -60496,6 +61191,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-15/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -60531,6 +61230,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-15/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -60562,6 +61265,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-15/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -60597,6 +61304,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-15/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -60628,6 +61339,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-15/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -60663,6 +61378,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-16/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -60694,6 +61413,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-16/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -60729,6 +61452,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-16/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -60760,6 +61487,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-16/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -60795,6 +61526,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-16/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -60826,6 +61561,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-17/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -60861,6 +61600,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-17/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -60892,6 +61635,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-17/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -60927,6 +61674,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-17/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -60958,6 +61709,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-17/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -60993,6 +61748,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-18/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -61024,6 +61783,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-18/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -61059,6 +61822,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-18/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -61090,6 +61857,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-18/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -61125,6 +61896,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-18/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -61156,6 +61931,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-19/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -61191,6 +61970,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-19/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -61222,6 +62005,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-19/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -61257,6 +62044,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-19/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -61288,6 +62079,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-19/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -61323,6 +62118,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-20/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -61354,6 +62153,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-20/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -61389,6 +62192,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-20/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -61420,6 +62227,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-20/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -61455,6 +62266,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-20/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -61486,6 +62301,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-21/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -61521,6 +62340,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-21/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -61552,6 +62375,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-21/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -61587,6 +62414,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-21/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -61618,6 +62449,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-21/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -61653,6 +62488,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-22/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -61684,6 +62523,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-22/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -61719,6 +62562,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-22/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -61750,6 +62597,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-22/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -61785,6 +62636,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-22/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -61816,6 +62671,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-23/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -61851,6 +62710,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-23/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -61882,6 +62745,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-23/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -61917,6 +62784,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-23/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -61948,6 +62819,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-23/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -61983,6 +62858,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-24/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -62014,6 +62893,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-24/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -62049,6 +62932,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-24/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -62080,6 +62967,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-24/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -62115,6 +63006,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-24/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -62146,6 +63041,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-25/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -62181,6 +63080,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-25/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -62212,6 +63115,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-25/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -62247,6 +63154,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-25/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -62278,6 +63189,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-25/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -62313,6 +63228,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-26/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -62344,6 +63263,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-26/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -62379,6 +63302,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-26/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -62410,6 +63337,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-26/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -62445,6 +63376,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-26/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -62476,6 +63411,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-27/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -62511,6 +63450,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-27/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -62542,6 +63485,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-27/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -62577,6 +63524,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-27/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -62608,6 +63559,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-27/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -62643,6 +63598,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-28/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -62674,6 +63633,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-28/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -62709,6 +63672,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-28/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -62740,6 +63707,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-28/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -62775,6 +63746,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-28/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -62806,6 +63781,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-29/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -62841,6 +63820,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-29/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -62872,6 +63855,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-29/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -62907,6 +63894,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-29/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -62938,6 +63929,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-29/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -62973,6 +63968,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-30/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -63004,6 +64003,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-30/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -63039,6 +64042,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-30/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -63070,6 +64077,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-30/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -63105,6 +64116,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-30/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -63136,6 +64151,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-31/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -63171,6 +64190,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-31/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -63202,6 +64225,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-31/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -63237,6 +64264,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-31/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -63268,6 +64299,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-31/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -63303,6 +64338,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -63334,6 +64373,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -63369,6 +64412,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -63400,6 +64447,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/fan-card-connector-0/winthrop-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -63435,6 +64486,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/fan-card-connector-0/winthrop-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -63466,6 +64521,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/dasd-card-connector-0/pyramid-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -63501,6 +64560,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/dasd-card-connector-0/pyramid-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -63532,6 +64595,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/dasd-card-connector-0/pyramid-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -63567,6 +64634,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -63598,6 +64669,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -63633,6 +64708,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -63664,6 +64743,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -63699,6 +64782,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -63730,6 +64817,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -63765,6 +64856,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -63796,6 +64891,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -63831,6 +64930,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -63862,6 +64965,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -63897,6 +65004,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -63928,6 +65039,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -63963,6 +65078,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -63994,6 +65113,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -64029,6 +65152,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -64060,6 +65187,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -64095,6 +65226,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -64126,6 +65261,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -64161,6 +65300,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -64192,6 +65335,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -64227,6 +65374,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -64258,6 +65409,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -64293,6 +65448,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -64324,6 +65483,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -64359,6 +65522,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -64390,6 +65557,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -64425,6 +65596,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -64456,6 +65631,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -64491,6 +65670,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -64522,6 +65705,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -64557,6 +65744,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -64588,6 +65779,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -64623,6 +65818,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -64654,6 +65853,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -64689,6 +65892,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -64720,6 +65927,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -64755,6 +65966,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -64786,6 +66001,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -64821,6 +66040,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -64852,6 +66075,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -64887,6 +66114,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -64918,6 +66149,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -64953,6 +66188,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -64984,6 +66223,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -65019,6 +66262,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -65050,6 +66297,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -65085,6 +66336,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -65116,6 +66371,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -65151,6 +66410,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -65182,6 +66445,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -65217,6 +66484,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -65248,6 +66519,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -65283,6 +66558,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -65314,6 +66593,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -65349,6 +66632,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -65380,6 +66667,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -65415,6 +66706,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/tpm-connector-0/wilson-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -65446,6 +66741,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -65481,6 +66780,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -65512,6 +66815,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -65547,6 +66854,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -65578,6 +66889,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -65613,6 +66928,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -65644,6 +66963,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -65679,6 +67002,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-0/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -65710,6 +67037,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-0/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -65745,6 +67076,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-0/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -65776,6 +67111,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-0/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -65811,6 +67150,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-0/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -65842,6 +67185,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-0/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -65877,6 +67224,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-0/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -65908,6 +67259,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-0/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -65943,6 +67298,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-0/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -65974,6 +67333,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-0/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -66009,6 +67372,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-0/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -66040,6 +67407,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-1/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -66075,6 +67446,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-1/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -66106,6 +67481,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-1/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -66141,6 +67520,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-1/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -66172,6 +67555,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-1/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -66207,6 +67594,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-1/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -66238,6 +67629,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-1/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -66273,6 +67668,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-1/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -66304,6 +67703,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-1/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -66339,6 +67742,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-1/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -66370,6 +67777,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-1/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -66405,6 +67816,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-2/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -66436,6 +67851,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-2/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -66471,6 +67890,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-2/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -66502,6 +67925,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-2/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -66537,6 +67964,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-2/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -66568,6 +67999,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-2/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -66603,6 +68038,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-2/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -66634,6 +68073,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-2/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -66669,6 +68112,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-2/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -66700,6 +68147,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-2/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -66735,6 +68186,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-2/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -66766,6 +68221,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-3/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -66801,6 +68260,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-3/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -66832,6 +68295,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-3/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -66867,6 +68334,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-3/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -66898,6 +68369,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-3/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -66933,6 +68408,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-3/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -66964,6 +68443,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-3/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -66999,6 +68482,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-3/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -67030,6 +68517,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-3/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -67065,6 +68556,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-3/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -67096,6 +68591,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-3/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -67131,6 +68630,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-4/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -67162,6 +68665,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-4/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -67197,6 +68704,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-4/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -67228,6 +68739,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-4/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -67263,6 +68778,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-4/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -67294,6 +68813,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-4/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -67329,6 +68852,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-4/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -67360,6 +68887,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-4/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -67395,6 +68926,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-4/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -67426,6 +68961,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-4/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -67461,6 +69000,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-4/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -67492,6 +69035,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-5/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -67527,6 +69074,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-5/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -67558,6 +69109,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-5/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -67593,6 +69148,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-5/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -67624,6 +69183,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-5/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -67659,6 +69222,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-5/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -67690,6 +69257,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-5/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -67725,6 +69296,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-5/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -67756,6 +69331,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-5/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -67791,6 +69370,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-5/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -67822,6 +69405,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-5/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -67857,6 +69444,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-6/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -67888,6 +69479,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-6/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -67923,6 +69518,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-6/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -67954,6 +69553,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-6/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -67989,6 +69592,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-6/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -68020,6 +69627,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-6/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -68055,6 +69666,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-6/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -68086,6 +69701,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-6/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -68121,6 +69740,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-6/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -68152,6 +69775,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-6/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -68187,6 +69814,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-6/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -68218,6 +69849,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-7/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -68253,6 +69888,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-7/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -68284,6 +69923,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-7/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -68319,6 +69962,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-7/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -68350,6 +69997,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-7/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -68385,6 +70036,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-7/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -68416,6 +70071,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-7/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -68451,6 +70110,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-7/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -68482,6 +70145,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-7/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -68517,6 +70184,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-7/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -68548,6 +70219,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-7/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -68583,6 +70258,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-8/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -68614,6 +70293,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-8/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -68649,6 +70332,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-8/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -68680,6 +70367,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-8/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -68715,6 +70406,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-8/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -68746,6 +70441,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-8/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -68781,6 +70480,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-8/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -68812,6 +70515,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-8/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -68847,6 +70554,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-8/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -68878,6 +70589,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-8/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -68913,6 +70628,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-8/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -68944,6 +70663,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-9/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -68979,6 +70702,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-9/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -69010,6 +70737,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-9/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -69045,6 +70776,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-9/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -69076,6 +70811,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-9/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -69111,6 +70850,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-9/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -69142,6 +70885,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-9/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -69177,6 +70924,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-9/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -69208,6 +70959,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-9/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -69243,6 +70998,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-9/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -69274,6 +71033,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-9/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -69309,6 +71072,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-10/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -69340,6 +71107,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-10/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -69375,6 +71146,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-10/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -69406,6 +71181,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-10/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -69441,6 +71220,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-10/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -69472,6 +71255,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-10/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -69507,6 +71294,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-10/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -69538,6 +71329,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-10/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -69573,6 +71368,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-10/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -69604,6 +71403,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-10/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -69639,6 +71442,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-10/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -69670,6 +71477,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-11/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -69705,6 +71516,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-11/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -69736,6 +71551,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-11/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -69771,6 +71590,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-11/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -69802,6 +71625,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-11/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -69837,6 +71664,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-11/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -69868,6 +71699,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-11/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -69903,6 +71738,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-11/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -69934,6 +71773,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-11/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -69969,6 +71812,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-11/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -70000,6 +71847,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-11/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -70035,6 +71886,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-12/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -70066,6 +71921,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-12/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -70101,6 +71960,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-12/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -70132,6 +71995,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-12/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -70167,6 +72034,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-12/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -70198,6 +72069,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-12/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -70233,6 +72108,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-12/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -70264,6 +72143,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-12/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -70299,6 +72182,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-12/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -70330,6 +72217,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-12/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -70365,6 +72256,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-12/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -70396,6 +72291,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-13/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -70431,6 +72330,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-13/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -70462,6 +72365,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-13/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -70497,6 +72404,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-13/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -70528,6 +72439,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-13/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -70563,6 +72478,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-13/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -70594,6 +72513,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-13/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -70629,6 +72552,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-13/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -70660,6 +72587,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-13/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -70695,6 +72626,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-13/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -70726,6 +72661,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-13/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -70761,6 +72700,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-14/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -70792,6 +72735,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-14/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -70827,6 +72774,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-14/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -70858,6 +72809,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-14/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -70893,6 +72848,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-14/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -70924,6 +72883,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-14/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -70959,6 +72922,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-14/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -70990,6 +72957,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-14/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -71025,6 +72996,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-14/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -71056,6 +73031,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-14/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -71091,6 +73070,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-14/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -71122,6 +73105,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-15/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -71157,6 +73144,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-15/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -71188,6 +73179,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-15/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -71223,6 +73218,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-15/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -71254,6 +73253,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-15/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -71289,6 +73292,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-15/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -71320,6 +73327,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-15/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -71355,6 +73366,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-15/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -71386,6 +73401,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-15/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -71421,6 +73440,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-15/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -71452,6 +73475,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-15/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -71487,6 +73514,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-16/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -71518,6 +73549,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-16/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -71553,6 +73588,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-16/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -71584,6 +73623,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-16/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -71619,6 +73662,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-16/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -71650,6 +73697,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-16/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -71685,6 +73736,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-16/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -71716,6 +73771,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-16/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -71751,6 +73810,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-16/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -71782,6 +73845,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-16/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -71817,6 +73884,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-16/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -71848,6 +73919,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-17/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -71883,6 +73958,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-17/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -71914,6 +73993,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-17/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -71949,6 +74032,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-17/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -71980,6 +74067,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-17/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -72015,6 +74106,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-17/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -72046,6 +74141,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-17/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -72081,6 +74180,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-17/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -72112,6 +74215,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-17/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -72147,6 +74254,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-17/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -72178,6 +74289,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-17/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -72213,6 +74328,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-18/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -72244,6 +74363,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-18/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -72279,6 +74402,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-18/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -72310,6 +74437,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-18/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -72345,6 +74476,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-18/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -72376,6 +74511,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-18/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -72411,6 +74550,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-18/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -72442,6 +74585,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-18/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -72477,6 +74624,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-18/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -72508,6 +74659,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-18/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -72543,6 +74698,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-18/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -72574,6 +74733,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-19/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -72609,6 +74772,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-19/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -72640,6 +74807,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-19/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -72675,6 +74846,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-19/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -72706,6 +74881,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-19/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -72741,6 +74920,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-19/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -72772,6 +74955,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-19/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -72807,6 +74994,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-19/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -72838,6 +75029,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-19/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -72873,6 +75068,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-19/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -72904,6 +75103,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-19/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -72939,6 +75142,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-20/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -72970,6 +75177,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-20/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -73005,6 +75216,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-20/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -73036,6 +75251,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-20/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -73071,6 +75290,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-20/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -73102,6 +75325,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-20/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -73137,6 +75364,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-20/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -73168,6 +75399,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-20/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -73203,6 +75438,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-20/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -73234,6 +75473,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-20/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -73269,6 +75512,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-20/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -73300,6 +75547,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-21/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -73335,6 +75586,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-21/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -73366,6 +75621,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-21/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -73401,6 +75660,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-21/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -73432,6 +75695,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-21/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -73467,6 +75734,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-21/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -73498,6 +75769,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-21/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -73533,6 +75808,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-21/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -73564,6 +75843,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-21/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -73599,6 +75882,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-21/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -73630,6 +75917,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-21/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -73665,6 +75956,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-22/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -73696,6 +75991,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-22/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -73731,6 +76030,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-22/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -73762,6 +76065,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-22/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -73797,6 +76104,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-22/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -73828,6 +76139,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-22/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -73863,6 +76178,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-22/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -73894,6 +76213,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-22/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -73929,6 +76252,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-22/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -73960,6 +76287,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-22/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -73995,6 +76326,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-22/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -74026,6 +76361,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-23/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -74061,6 +76400,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-23/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -74092,6 +76435,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-23/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -74127,6 +76474,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-23/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -74158,6 +76509,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-23/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -74193,6 +76548,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-23/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -74224,6 +76583,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-23/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -74259,6 +76622,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-23/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -74290,6 +76657,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-23/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -74325,6 +76696,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-23/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -74356,6 +76731,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-23/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -74391,6 +76770,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-24/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -74422,6 +76805,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-24/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -74457,6 +76844,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-24/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -74488,6 +76879,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-24/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -74523,6 +76918,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-24/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -74554,6 +76953,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-24/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -74589,6 +76992,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-24/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -74620,6 +77027,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-24/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -74655,6 +77066,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-24/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -74686,6 +77101,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-24/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -74721,6 +77140,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-24/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -74752,6 +77175,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-25/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -74787,6 +77214,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-25/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -74818,6 +77249,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-25/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -74853,6 +77288,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-25/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -74884,6 +77323,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-25/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -74919,6 +77362,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-25/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -74950,6 +77397,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-25/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -74985,6 +77436,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-25/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -75016,6 +77471,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-25/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -75051,6 +77510,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-25/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -75082,6 +77545,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-25/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -75117,6 +77584,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-26/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -75148,6 +77619,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-26/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -75183,6 +77658,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-26/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -75214,6 +77693,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-26/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -75249,6 +77732,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-26/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -75280,6 +77767,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-26/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -75315,6 +77806,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-26/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -75346,6 +77841,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-26/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -75381,6 +77880,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-26/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -75412,6 +77915,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-26/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -75447,6 +77954,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-26/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -75478,6 +77989,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-27/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -75513,6 +78028,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-27/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -75544,6 +78063,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-27/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -75579,6 +78102,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-27/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -75610,6 +78137,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-27/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -75645,6 +78176,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-27/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -75676,6 +78211,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-27/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -75711,6 +78250,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-27/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -75742,6 +78285,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-27/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -75777,6 +78324,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-27/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -75808,6 +78359,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-27/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -75843,6 +78398,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-28/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -75874,6 +78433,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-28/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -75909,6 +78472,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-28/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -75940,6 +78507,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-28/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -75975,6 +78546,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-28/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -76006,6 +78581,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-28/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -76041,6 +78620,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-28/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -76072,6 +78655,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-28/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -76107,6 +78694,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-28/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -76138,6 +78729,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-28/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -76173,6 +78768,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-28/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -76204,6 +78803,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-29/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -76239,6 +78842,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-29/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -76270,6 +78877,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-29/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -76305,6 +78916,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-29/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -76336,6 +78951,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-29/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -76371,6 +78990,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-29/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -76402,6 +79025,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-29/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -76437,6 +79064,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-29/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -76468,6 +79099,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-29/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -76503,6 +79138,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-29/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -76534,6 +79173,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-29/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -76569,6 +79212,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-30/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -76600,6 +79247,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-30/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -76635,6 +79286,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-30/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -76666,6 +79321,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-30/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -76701,6 +79360,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-30/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -76732,6 +79395,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-30/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -76767,6 +79434,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-30/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -76798,6 +79469,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-30/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -76833,6 +79508,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-30/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -76864,6 +79543,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-30/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -76899,6 +79582,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-30/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -76930,6 +79617,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-31/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -76965,6 +79656,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-31/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -76996,6 +79691,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-31/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -77031,6 +79730,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-31/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -77062,6 +79765,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-31/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -77097,6 +79804,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-31/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -77128,6 +79839,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-31/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -77163,6 +79878,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-31/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -77194,6 +79913,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-31/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -77229,6 +79952,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-31/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -77262,6 +79989,10 @@
 		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-31/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -77293,6 +80024,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -78541,6 +81276,10 @@
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
+		</bus_attribute>
 	</bus>
 	<bus>
 		<bus_id>proc_socket-0/godel-0/power10-0/mc0/mi0/mcc0/omic0/omi1 => ddimm-connector-1/ddimm-0/ocmb/omi</bus_id>
@@ -78553,6 +81292,10 @@
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -78567,6 +81310,10 @@
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
+		</bus_attribute>
 	</bus>
 	<bus>
 		<bus_id>proc_socket-0/godel-0/power10-0/mc0/mi0/mcc1/omic1/omi3 => ddimm-connector-3/ddimm-0/ocmb/omi</bus_id>
@@ -78579,6 +81326,10 @@
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -78593,6 +81344,10 @@
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
+		</bus_attribute>
 	</bus>
 	<bus>
 		<bus_id>proc_socket-0/godel-0/power10-0/mc1/mi1/mcc2/omic2/omi5 => ddimm-connector-5/ddimm-0/ocmb/omi</bus_id>
@@ -78605,6 +81360,10 @@
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -78619,6 +81378,10 @@
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
+		</bus_attribute>
 	</bus>
 	<bus>
 		<bus_id>proc_socket-0/godel-0/power10-0/mc1/mi1/mcc3/omic3/omi7 => ddimm-connector-7/ddimm-0/ocmb/omi</bus_id>
@@ -78631,6 +81394,10 @@
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -78645,6 +81412,10 @@
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
+		</bus_attribute>
 	</bus>
 	<bus>
 		<bus_id>proc_socket-1/godel-0/power10-0/mc0/mi0/mcc0/omic0/omi1 => ddimm-connector-17/ddimm-0/ocmb/omi</bus_id>
@@ -78657,6 +81428,10 @@
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -78671,6 +81446,10 @@
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
+		</bus_attribute>
 	</bus>
 	<bus>
 		<bus_id>proc_socket-1/godel-0/power10-0/mc0/mi0/mcc1/omic1/omi3 => ddimm-connector-19/ddimm-0/ocmb/omi</bus_id>
@@ -78683,6 +81462,10 @@
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -78697,6 +81480,10 @@
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
+		</bus_attribute>
 	</bus>
 	<bus>
 		<bus_id>proc_socket-1/godel-0/power10-0/mc1/mi1/mcc2/omic2/omi5 => ddimm-connector-21/ddimm-0/ocmb/omi</bus_id>
@@ -78709,6 +81496,10 @@
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -78723,6 +81514,10 @@
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
+		</bus_attribute>
 	</bus>
 	<bus>
 		<bus_id>proc_socket-1/godel-0/power10-0/mc1/mi1/mcc3/omic3/omi7 => ddimm-connector-23/ddimm-0/ocmb/omi</bus_id>
@@ -78735,6 +81530,10 @@
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -78749,6 +81548,10 @@
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
+		</bus_attribute>
 	</bus>
 	<bus>
 		<bus_id>proc_socket-0/godel-0/power10-1/mc2/mi2/mcc4/omic4/omi9 => ddimm-connector-9/ddimm-0/ocmb/omi</bus_id>
@@ -78761,6 +81564,10 @@
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -78775,6 +81582,10 @@
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
+		</bus_attribute>
 	</bus>
 	<bus>
 		<bus_id>proc_socket-0/godel-0/power10-1/mc2/mi2/mcc5/omic5/omi11 => ddimm-connector-11/ddimm-0/ocmb/omi</bus_id>
@@ -78787,6 +81598,10 @@
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -78801,6 +81616,10 @@
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
+		</bus_attribute>
 	</bus>
 	<bus>
 		<bus_id>proc_socket-0/godel-0/power10-1/mc3/mi3/mcc6/omic6/omi13 => ddimm-connector-13/ddimm-0/ocmb/omi</bus_id>
@@ -78813,6 +81632,10 @@
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -78827,6 +81650,10 @@
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
+		</bus_attribute>
 	</bus>
 	<bus>
 		<bus_id>proc_socket-0/godel-0/power10-1/mc3/mi3/mcc7/omic7/omi15 => ddimm-connector-15/ddimm-0/ocmb/omi</bus_id>
@@ -78839,6 +81666,10 @@
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -78853,6 +81684,10 @@
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
+		</bus_attribute>
 	</bus>
 	<bus>
 		<bus_id>proc_socket-1/godel-0/power10-1/mc2/mi2/mcc4/omic4/omi9 => ddimm-connector-25/ddimm-0/ocmb/omi</bus_id>
@@ -78865,6 +81700,10 @@
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -78879,6 +81718,10 @@
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
+		</bus_attribute>
 	</bus>
 	<bus>
 		<bus_id>proc_socket-1/godel-0/power10-1/mc2/mi2/mcc5/omic5/omi11 => ddimm-connector-27/ddimm-0/ocmb/omi</bus_id>
@@ -78891,6 +81734,10 @@
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -78905,6 +81752,10 @@
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
+		</bus_attribute>
 	</bus>
 	<bus>
 		<bus_id>proc_socket-1/godel-0/power10-1/mc3/mi3/mcc6/omic6/omi13 => ddimm-connector-29/ddimm-0/ocmb/omi</bus_id>
@@ -78917,6 +81768,10 @@
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -78931,6 +81786,10 @@
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
+		</bus_attribute>
 	</bus>
 	<bus>
 		<bus_id>proc_socket-1/godel-0/power10-1/mc3/mi3/mcc7/omic7/omi15 => ddimm-connector-31/ddimm-0/ocmb/omi</bus_id>
@@ -78943,6 +81802,10 @@
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default></default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -98499,6 +101362,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -98532,6 +101399,10 @@
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0)</default>
 		</bus_attribute>
 		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
 			<id>I2C_PURPOSE</id>
 		<default></default>
 		</bus_attribute>
@@ -98563,6 +101434,10 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_PURPOSE</id>
@@ -146131,6 +149006,7 @@
 	<child_id>vrd-i2c.enable</child_id>
 	<child_id>vrd-i2c.vin</child_id>
 	<child_id>vrd-i2c.vout</child_id>
+	<child_id>avs-slave</child_id>
 	<attribute>
 		<id>AFFINITY_PATH</id>
 		<default></default>
@@ -146419,6 +149295,37 @@
 	</attribute>
 </targetInstance>
 <targetInstance>
+	<id>avs-slave</id>
+	<type>unit-avs-slave</type>
+	<is_root>false</is_root>
+	<instance_name>avs-slave</instance_name>
+	<position>-1</position>
+	<attribute>
+		<id>BUS_TYPE</id>
+		<default>AVS</default>
+	</attribute>
+	<attribute>
+		<id>CHIP_UNIT</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>UNIT</default>
+	</attribute>
+	<attribute>
+		<id>DIRECTION</id>
+		<default>IN</default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetInstance>
+<targetInstance>
 	<id>vdd-1</id>
 	<type>chip-vrd-i2c</type>
 	<is_root>false</is_root>
@@ -146429,6 +149336,7 @@
 	<child_id>vrd-i2c.enable</child_id>
 	<child_id>vrd-i2c.vin</child_id>
 	<child_id>vrd-i2c.vout</child_id>
+	<child_id>avs-slave</child_id>
 	<attribute>
 		<id>AFFINITY_PATH</id>
 		<default></default>
@@ -146657,6 +149565,7 @@
 	<child_id>vrd-i2c-2.vin</child_id>
 	<child_id>vrd-i2c-2.vout1</child_id>
 	<child_id>vrd-i2c-2.vout2</child_id>
+	<child_id>avs-slave</child_id>
 	<attribute>
 		<id>AFFINITY_PATH</id>
 		<default></default>
@@ -147119,6 +150028,7 @@
 	<child_id>vrd-i2c-2.vin</child_id>
 	<child_id>vrd-i2c-2.vout1</child_id>
 	<child_id>vrd-i2c-2.vout2</child_id>
+	<child_id>avs-slave</child_id>
 	<attribute>
 		<id>AFFINITY_PATH</id>
 		<default></default>
@@ -147185,6 +150095,7 @@
 	<child_id>vrd-i2c-2.vin</child_id>
 	<child_id>vrd-i2c-2.vout1</child_id>
 	<child_id>vrd-i2c-2.vout2</child_id>
+	<child_id>avs-slave</child_id>
 	<attribute>
 		<id>AFFINITY_PATH</id>
 		<default></default>
@@ -147251,6 +150162,7 @@
 	<child_id>vrd-i2c-2.vin</child_id>
 	<child_id>vrd-i2c-2.vout1</child_id>
 	<child_id>vrd-i2c-2.vout2</child_id>
+	<child_id>avs-slave</child_id>
 	<attribute>
 		<id>AFFINITY_PATH</id>
 		<default></default>
@@ -161941,6 +164853,7 @@
 	<child_id>cablecard-LED-CXP-TOP</child_id>
 	<child_id>cablecard-LED-CXP-BOT</child_id>
 	<child_id>i2c-slave</child_id>
+	<child_id>cablecard-TMP435</child_id>
 	<attribute>
 		<id>AFFINITY_PATH</id>
 		<default></default>
@@ -162780,6 +165693,109 @@
 	<attribute>
 		<id>VIEW_REAR</id>
 		<default>YES</default>
+	</attribute>
+</targetInstance>
+<targetInstance>
+	<id>cablecard-TMP435</id>
+	<type>chip-tmp-device</type>
+	<is_root>false</is_root>
+	<instance_name>cablecard-TMP435</instance_name>
+	<position>-1</position>
+	<child_id>TMP435-i2c</child_id>
+	<attribute>
+		<id>CLASS</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>COOLING_ZONE_MASK</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>I2C_ADDRESS</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>I2C_SPEED</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>TMP</default>
+	</attribute>
+	<attribute>
+		<id>POSITION</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>RU_TYPE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>TARGET-FRU-TYPE</id>
+		<default>planar</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetInstance>
+<targetInstance>
+	<id>TMP435-i2c</id>
+	<type>unit-i2c-slave</type>
+	<is_root>false</is_root>
+	<instance_name>TMP435-i2c</instance_name>
+	<position>-1</position>
+	<attribute>
+		<id>AFFINITY_PATH</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>BUS_TYPE</id>
+		<default>I2C</default>
+	</attribute>
+	<attribute>
+		<id>CHIP_UNIT</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>UNIT</default>
+	</attribute>
+	<attribute>
+		<id>DIRECTION</id>
+		<default>IN</default>
+	</attribute>
+	<attribute>
+		<id>FAPI_NAME</id>
+		<default>unknown</default>
+	</attribute>
+	<attribute>
+		<id>I2C_ADDRESS</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>MODEL</id>
+		<default>POWER10</default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>PHYS_PATH</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>VPD_SIZE</id>
+		<default>NA</default>
 	</attribute>
 </targetInstance>
 <targetInstance>

--- a/Rainier-4U-MRW.xml
+++ b/Rainier-4U-MRW.xml
@@ -2964,6 +2964,10 @@
 		<value>0x0</value>
 		</enumerator>
 		<enumerator>
+		<name>SKIP_FIRST_LOAD</name>
+		<value>0x3</value>
+		</enumerator>
+		<enumerator>
 		<name>DO_NOT_LOAD</name>
 		<value>0x2</value>
 		</enumerator>
@@ -3170,6 +3174,17 @@
 		<enumerator>
 		<name>2_BYTE</name>
 		<value>1</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>PROC_FAVOR_AGGRESSIVE_PREFETCH</id>
+		<enumerator>
+		<name>TRUE</name>
+		<value>1</value>
+		</enumerator>
+		<enumerator>
+		<name>FALSE</name>
+		<value>0</value>
 		</enumerator>
 </enumerationType>
 <enumerationType>
@@ -4655,6 +4670,10 @@
 	<property>
 	<id>FRU_ID</id>
 	<value>0</value>
+	</property>
+	<property>
+	<id>PROC_FABRIC_TOPOLOGY_MODE</id>
+	<value></value>
 	</property>
 	<property>
 	<id>RESOURCE_IS_CRITICAL</id>
@@ -50648,10 +50667,6 @@
 		<default>0x00</default>
 	</attribute>
 	<attribute>
-		<id>PLDM_CONNECTOR_PDRS_ENABLED</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
 		<id>PMIC_ERROR_TEMP_DEG_C</id>
 		<default>83</default>
 	</attribute>
@@ -50686,6 +50701,10 @@
 	<attribute>
 		<id>PROC_FABRIC_TOPOLOGY_MODE</id>
 		<default>MODE0</default>
+	</attribute>
+	<attribute>
+		<id>PROC_FAVOR_AGGRESSIVE_PREFETCH</id>
+		<default></default>
 	</attribute>
 	<attribute>
 		<id>PROC_IO_READ_TIMEOUT_SEC</id>
@@ -148905,7 +148924,7 @@
 	<child_id>vdd-vrm-vpd-0</child_id>
 	<child_id>vdd-0</child_id>
 	<child_id>vdd-1</child_id>
-   <child_id>avs-slave</child_id>
+	<child_id>avs-slave</child_id>
 	<attribute>
 		<id>CARD_TYPE</id>
 		<default>VRM</default>
@@ -149295,37 +149314,6 @@
 	</attribute>
 </targetInstance>
 <targetInstance>
-	<id>avs-slave</id>
-	<type>unit-avs-slave</type>
-	<is_root>false</is_root>
-	<instance_name>avs-slave</instance_name>
-	<position>-1</position>
-	<attribute>
-		<id>BUS_TYPE</id>
-		<default>AVS</default>
-	</attribute>
-	<attribute>
-		<id>CHIP_UNIT</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>CLASS</id>
-		<default>UNIT</default>
-	</attribute>
-	<attribute>
-		<id>DIRECTION</id>
-		<default>IN</default>
-	</attribute>
-	<attribute>
-		<id>MRW_TYPE</id>
-		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>TYPE</id>
-		<default>NA</default>
-	</attribute>
-</targetInstance>
-<targetInstance>
 	<id>vdd-1</id>
 	<type>chip-vrd-i2c</type>
 	<is_root>false</is_root>
@@ -149386,6 +149374,37 @@
 	<attribute>
 		<id>TYPE</id>
 		<default></default>
+	</attribute>
+</targetInstance>
+<targetInstance>
+	<id>avs-slave</id>
+	<type>unit-avs-slave</type>
+	<is_root>false</is_root>
+	<instance_name>avs-slave</instance_name>
+	<position>-1</position>
+	<attribute>
+		<id>BUS_TYPE</id>
+		<default>AVS</default>
+	</attribute>
+	<attribute>
+		<id>CHIP_UNIT</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>UNIT</default>
+	</attribute>
+	<attribute>
+		<id>DIRECTION</id>
+		<default>IN</default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
 	</attribute>
 </targetInstance>
 <targetInstance>
@@ -165745,10 +165764,6 @@
 	<instance_name>TMP435-i2c</instance_name>
 	<position>-1</position>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>I2C</default>
 	</attribute>
@@ -165765,28 +165780,12 @@
 		<default>IN</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
 		<id>I2C_ADDRESS</id>
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MODEL</id>
-		<default>POWER10</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>PHYS_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>RESOURCE_IS_CRITICAL</id>
-		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>

--- a/Rainier-4U-MRW.xml
+++ b/Rainier-4U-MRW.xml
@@ -51251,12 +51251,12 @@
 		<default>NA</default>
 	</attribute>
 	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-0/avs0-master => vdd-vrm-connector-0/vdd-vrm-0/vdd-0/avs-slave</bus_id>
+		<bus_id>proc_socket-0/godel-0/power10-0/avs0-master => vdd-vrm-connector-0/vdd-vrm-0/avs-slave</bus_id>
 		<bus_type>AVS</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-0/godel-0/power10-0/</source_path>
 		<source_target>avs0-master</source_target>
-		<dest_path>vdd-vrm-connector-0/vdd-vrm-0/vdd-0/</dest_path>
+		<dest_path>vdd-vrm-connector-0/vdd-vrm-0/</dest_path>
 		<dest_target>avs-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
@@ -51293,12 +51293,12 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-1/avs0-master => vdd-vrm-connector-0/vdd-vrm-0/vdd-1/avs-slave</bus_id>
+		<bus_id>proc_socket-0/godel-0/power10-1/avs0-master => vdd-vrm-connector-0/vdd-vrm-0/avs-slave</bus_id>
 		<bus_type>AVS</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-0/godel-0/power10-1/</source_path>
 		<source_target>avs0-master</source_target>
-		<dest_path>vdd-vrm-connector-0/vdd-vrm-0/vdd-1/</dest_path>
+		<dest_path>vdd-vrm-connector-0/vdd-vrm-0/</dest_path>
 		<dest_target>avs-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
@@ -51335,12 +51335,12 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-0/avs0-master => vdd-vrm-connector-1/vdd-vrm-0/vdd-0/avs-slave</bus_id>
+		<bus_id>proc_socket-1/godel-0/power10-0/avs0-master => vdd-vrm-connector-1/vdd-vrm-0/avs-slave</bus_id>
 		<bus_type>AVS</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-1/godel-0/power10-0/</source_path>
 		<source_target>avs0-master</source_target>
-		<dest_path>vdd-vrm-connector-1/vdd-vrm-0/vdd-0/</dest_path>
+		<dest_path>vdd-vrm-connector-1/vdd-vrm-0/</dest_path>
 		<dest_target>avs-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
@@ -51377,12 +51377,12 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-1/avs0-master => vdd-vrm-connector-1/vdd-vrm-0/vdd-1/avs-slave</bus_id>
+		<bus_id>proc_socket-1/godel-0/power10-1/avs0-master => vdd-vrm-connector-1/vdd-vrm-0/avs-slave</bus_id>
 		<bus_type>AVS</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-1/godel-0/power10-1/</source_path>
 		<source_target>avs0-master</source_target>
-		<dest_path>vdd-vrm-connector-1/vdd-vrm-0/vdd-1/</dest_path>
+		<dest_path>vdd-vrm-connector-1/vdd-vrm-0/</dest_path>
 		<dest_target>avs-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
@@ -148905,6 +148905,7 @@
 	<child_id>vdd-vrm-vpd-0</child_id>
 	<child_id>vdd-0</child_id>
 	<child_id>vdd-1</child_id>
+   <child_id>avs-slave</child_id>
 	<attribute>
 		<id>CARD_TYPE</id>
 		<default>VRM</default>
@@ -149006,7 +149007,6 @@
 	<child_id>vrd-i2c.enable</child_id>
 	<child_id>vrd-i2c.vin</child_id>
 	<child_id>vrd-i2c.vout</child_id>
-	<child_id>avs-slave</child_id>
 	<attribute>
 		<id>AFFINITY_PATH</id>
 		<default></default>
@@ -149336,7 +149336,6 @@
 	<child_id>vrd-i2c.enable</child_id>
 	<child_id>vrd-i2c.vin</child_id>
 	<child_id>vrd-i2c.vout</child_id>
-	<child_id>avs-slave</child_id>
 	<attribute>
 		<id>AFFINITY_PATH</id>
 		<default></default>


### PR DESCRIPTION
https://w3.rchland.ibm.com/projects/bestquest/?defect=SW551825

Extra change that is not related to FRU_PATH or avs_slave attribute are part of the newer common_mrw change. should be dont care for this change.
DCM0:
     chip0--avs0--C14--vdd-0
     chip0--avs1-- vdn-vcs0 (located on system planar P0)
     chip1--avs0--C14--vdd-1
     chip1--avs1--vio-vcs0 (located on system planar P0)
DCM1:
     chip0--avs0--C23--vdd-0
     chip0--avs1-- vdn-vcs-1 (located on system planar P0)
     chip1--avs0--C23--vdd-1
     chip1--avs1--vio-vcs-1 (located on system planar P0)