### PR TITLE
Adding missing OMI FRU_PATH information accidentally removed on 2/9/22

### DIFF
--- a/Rainier-2U-MRW.xml
+++ b/Rainier-2U-MRW.xml
@@ -61063,7 +61063,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-0/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -61080,7 +61080,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-1/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -61097,7 +61097,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-2/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -61114,7 +61114,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-3/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -61131,7 +61131,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-4/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -61148,7 +61148,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-5/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -61165,7 +61165,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-6/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -61182,7 +61182,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-7/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -61199,7 +61199,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-16/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -61216,7 +61216,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-17/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -61233,7 +61233,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-18/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -61250,7 +61250,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-19/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -61267,7 +61267,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-20/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -61284,7 +61284,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-21/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -61301,7 +61301,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-22/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -61318,7 +61318,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-23/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -61335,7 +61335,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-8/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -61352,7 +61352,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-9/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -61369,7 +61369,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-10/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -61386,7 +61386,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-11/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -61403,7 +61403,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-12/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -61420,7 +61420,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-13/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -61437,7 +61437,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-14/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -61454,7 +61454,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-15/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -61471,7 +61471,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-24/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -61488,7 +61488,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-25/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -61505,7 +61505,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-26/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -61522,7 +61522,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-27/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -61539,7 +61539,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-28/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -61556,7 +61556,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-29/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -61573,7 +61573,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-30/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -61590,7 +61590,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-31/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>

--- a/Rainier-4U-MRW.xml
+++ b/Rainier-4U-MRW.xml
@@ -81317,7 +81317,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-0/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -81334,7 +81334,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-1/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -81351,7 +81351,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-2/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -81368,7 +81368,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-3/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -81385,7 +81385,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-4/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -81402,7 +81402,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-5/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -81419,7 +81419,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-6/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -81436,7 +81436,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-7/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -81453,7 +81453,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-16/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -81470,7 +81470,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-17/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -81487,7 +81487,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-18/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -81504,7 +81504,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-19/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -81521,7 +81521,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-20/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -81538,7 +81538,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-21/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -81555,7 +81555,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-22/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -81572,7 +81572,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-23/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -81589,7 +81589,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-8/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -81606,7 +81606,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-9/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -81623,7 +81623,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-10/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -81640,7 +81640,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-11/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -81657,7 +81657,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-12/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -81674,7 +81674,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-13/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -81691,7 +81691,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-14/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -81708,7 +81708,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-15/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -81725,7 +81725,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-24/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -81742,7 +81742,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-25/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -81759,7 +81759,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-26/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -81776,7 +81776,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-27/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -81793,7 +81793,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-28/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -81810,7 +81810,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-29/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -81827,7 +81827,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-30/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -81844,7 +81844,7 @@
 		</bus_attribute>
 		<bus_attribute>
 			<id>FRU_PATH</id>
-		<default></default>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-31/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
 		</bus_attribute>
 	</bus>
 	<bus>


### PR DESCRIPTION
Adding back the FRU_PATH correct information for call-outs on all OMI bus connections for Rainier 2U and 4U MRW files. This was found per debug on IBM defect PE00DNNY. 

It was accidentally removed by the SW2 tool on 2/9/22, but had been originally added on 11/8/21. This has the effect of not listing all the proper FRUs when calling out OMI related errors. 

PE00DNNY : HST:RAS:STC1030:Rainier:Memory:System planar data missing from callout list