### PR TITLE
Added new attribute values for LI 14L PCAP by PSU number, type & inputV

### DIFF
--- a/Rainier-2U-MRW.xml
+++ b/Rainier-2U-MRW.xml
@@ -891,6 +891,10 @@
 		<value>0</value>
 		</enumerator>
 		<enumerator>
+		<name>PLANAR_OCMB_SPD</name>
+		<value>9</value>
+		</enumerator>
+		<enumerator>
 		<name>WOF_DATA</name>
 		<value>7</value>
 		</enumerator>
@@ -1037,13 +1041,6 @@
 		<enumerator>
 		<name>OCC</name>
 		<value>0x03</value>
-		</enumerator>
-</enumerationType>
-<enumerationType>
-	<id>FAPI_POS</id>
-		<enumerator>
-		<name>NA</name>
-		<value>0xFFFFFFFF</value>
 		</enumerator>
 </enumerationType>
 <enumerationType>
@@ -1582,6 +1579,17 @@
 		</enumerator>
 </enumerationType>
 <enumerationType>
+	<id>IOHS_SMP9_INTERCONNECT</id>
+		<enumerator>
+		<name>TRUE</name>
+		<value>0x1</value>
+		</enumerator>
+		<enumerator>
+		<name>FALSE</name>
+		<value>0x0</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
 	<id>IOHS_SPREAD_SPECTRUM</id>
 		<enumerator>
 		<name>DISABLED</name>
@@ -1604,6 +1612,17 @@
 		</enumerator>
 		<enumerator>
 		<name>HIGH_LOSS</name>
+		<value>0x00</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>IO_IOHS_XTALK</id>
+		<enumerator>
+		<name>HI_XTALK</name>
+		<value>0x01</value>
+		</enumerator>
+		<enumerator>
+		<name>NO_XTALK</name>
 		<value>0x00</value>
 		</enumerator>
 </enumerationType>
@@ -2076,10 +2095,6 @@
 		<value>0x0001</value>
 		</enumerator>
 		<enumerator>
-		<name>EX</name>
-		<value>0x0202</value>
-		</enumerator>
-		<enumerator>
 		<name>PCI</name>
 		<value>0x0303</value>
 		</enumerator>
@@ -2094,6 +2109,10 @@
 		<enumerator>
 		<name>MCS</name>
 		<value>0x0207</value>
+		</enumerator>
+		<enumerator>
+		<name>FC</name>
+		<value>0x0202</value>
 		</enumerator>
 		<enumerator>
 		<name>SP-CHIP</name>
@@ -2286,6 +2305,17 @@
 		</enumerator>
 </enumerationType>
 <enumerationType>
+	<id>MSS_MRW_DDR5_DRAM_READ_CRC</id>
+		<enumerator>
+		<name>DISABLE</name>
+		<value>0</value>
+		</enumerator>
+		<enumerator>
+		<name>ENABLE</name>
+		<value>1</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
 	<id>MSS_MRW_DIMM_HEIGHT_MIXING_POLICY</id>
 		<enumerator>
 		<name>ALLOWED</name>
@@ -2350,6 +2380,10 @@
 		<enumerator>
 		<name>FLY_2X</name>
 		<value>5</value>
+		</enumerator>
+		<enumerator>
+		<name>DDR5_FINE</name>
+		<value>7</value>
 		</enumerator>
 		<enumerator>
 		<name>FIXED_4X</name>
@@ -2687,6 +2721,10 @@
 		<enumerator>
 		<name>EXPLORER</name>
 		<value>0x8</value>
+		</enumerator>
+		<enumerator>
+		<name>ODYSSEY</name>
+		<value>0xB</value>
 		</enumerator>
 		<enumerator>
 		<name>NONE</name>
@@ -3174,17 +3212,6 @@
 		<enumerator>
 		<name>2_BYTE</name>
 		<value>1</value>
-		</enumerator>
-</enumerationType>
-<enumerationType>
-	<id>PROC_FAVOR_AGGRESSIVE_PREFETCH</id>
-		<enumerator>
-		<name>TRUE</name>
-		<value>1</value>
-		</enumerator>
-		<enumerator>
-		<name>FALSE</name>
-		<value>0</value>
 		</enumerator>
 </enumerationType>
 <enumerationType>
@@ -42048,6 +42075,18 @@
 		<default>NONE</default>
 	</attribute>
 	<attribute>
+		<id>INDEX_N_BULK_POWER_LIMIT_WATTS</id>
+		<default>1880,930,0,0,0,0,0,0,0,0,0,0</default>
+	</attribute>
+	<attribute>
+		<id>INDEX_N_PLUS_ONE_BULK_POWER_LIMIT_WATTS</id>
+		<default>2500,1250,0,0,0,0,0,0,0,0,0,0</default>
+	</attribute>
+	<attribute>
+		<id>INDEX_POWER_LIMIT_CONFIG</id>
+		<default>0x51E90202,0x51E90102,0,0,0,0,0,0,0,0,0,0</default>
+	</attribute>
+	<attribute>
 		<id>IPMI_SENSORS</id>
 		<default></default>
 	</attribute>
@@ -42312,6 +42351,10 @@
 		<default></default>
 	</attribute>
 	<attribute>
+		<id>MSS_MRW_DDR5_DRAM_READ_CRC</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>MSS_MRW_DIMM_HEIGHT_MIXING_POLICY</id>
 		<default>NOT_ALLOWED</default>
 	</attribute>
@@ -42374,6 +42417,10 @@
 	<attribute>
 		<id>MSS_MRW_OCMB_PWR_SLOPE</id>
 		<default>0x2DFFFC0001EC0000,0x3DFFFC0002A80000,0x4DFFFC0002D00000,0x5DFFFC0002CD0000,0xFFFFFC0002BC0000,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00</default>
+	</attribute>
+	<attribute>
+		<id>MSS_MRW_OCMB_SAFEMODE_UTIL_ARRAY</id>
+		<default></default>
 	</attribute>
 	<attribute>
 		<id>MSS_MRW_OCMB_THERMAL_MEMORY_POWER_LIMIT</id>
@@ -42635,10 +42682,6 @@
 		<default>MODE0</default>
 	</attribute>
 	<attribute>
-		<id>PROC_FAVOR_AGGRESSIVE_PREFETCH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>PROC_IO_READ_TIMEOUT_SEC</id>
 		<default>5</default>
 	</attribute>
@@ -42833,6 +42876,10 @@
 	<attribute>
 		<id>SYSTEM_VDM_DISABLE</id>
 		<default>0x00</default>
+	</attribute>
+	<attribute>
+		<id>SYS_CLOCK_INTEGRATED_SPARES</id>
+		<default></default>
 	</attribute>
 	<attribute>
 		<id>SYS_VFRT_STATIC_DATA_ENABLE</id>
@@ -43171,7 +43218,7 @@
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
-		<default></default>
+		<default>null</default>
 	</attribute>
 	<attribute>
 		<id>MRW_TYPE</id>
@@ -63396,10 +63443,6 @@
 		<default>pu:k0:n0:s0:p00</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
 		<id>FREQ_CORE_BOOT_MHZ</id>
 		<default>0x7D0</default>
 	</attribute>
@@ -63697,10 +63740,6 @@
 		<default>pu.eq:k0:n0:s0:p00:c0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -63752,10 +63791,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -63810,10 +63845,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>pu.c:k0:n0:s0:p00:c0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -64023,10 +64054,6 @@
 		<default>pu.c:k0:n0:s0:p00:c1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>1</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -64078,10 +64105,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -64138,10 +64161,6 @@
 		<default>pu.c:k0:n0:s0:p00:c2</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>2</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -64194,10 +64213,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>pu.c:k0:n0:s0:p00:c3</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>3</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -64253,10 +64268,6 @@
 		<default>pu.eq:k0:n0:s0:p00:c1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>1</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -64308,10 +64319,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -64368,10 +64375,6 @@
 		<default>pu.c:k0:n0:s0:p00:c4</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>4</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -64426,10 +64429,6 @@
 		<default>pu.c:k0:n0:s0:p00:c5</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>5</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -64481,10 +64480,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -64541,10 +64536,6 @@
 		<default>pu.c:k0:n0:s0:p00:c6</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>6</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -64597,10 +64588,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>pu.c:k0:n0:s0:p00:c7</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>7</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -64656,10 +64643,6 @@
 		<default>pu.eq:k0:n0:s0:p00:c2</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>2</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -64711,10 +64694,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -64771,10 +64750,6 @@
 		<default>pu.c:k0:n0:s0:p00:c8</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>8</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -64829,10 +64804,6 @@
 		<default>pu.c:k0:n0:s0:p00:c9</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>9</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -64884,10 +64855,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -64944,10 +64911,6 @@
 		<default>pu.c:k0:n0:s0:p00:c10</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>10</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -65000,10 +64963,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>pu.c:k0:n0:s0:p00:c11</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>11</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -65059,10 +65018,6 @@
 		<default>pu.eq:k0:n0:s0:p00:c3</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>3</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -65114,10 +65069,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -65174,10 +65125,6 @@
 		<default>pu.c:k0:n0:s0:p00:c12</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>12</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -65232,10 +65179,6 @@
 		<default>pu.c:k0:n0:s0:p00:c13</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>13</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -65287,10 +65230,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -65347,10 +65286,6 @@
 		<default>pu.c:k0:n0:s0:p00:c14</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>14</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -65403,10 +65338,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>pu.c:k0:n0:s0:p00:c15</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>15</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -65462,10 +65393,6 @@
 		<default>pu.eq:k0:n0:s0:p00:c4</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>4</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -65517,10 +65444,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -65577,10 +65500,6 @@
 		<default>pu.c:k0:n0:s0:p00:c16</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>16</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -65635,10 +65554,6 @@
 		<default>pu.c:k0:n0:s0:p00:c17</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>17</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -65690,10 +65605,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -65750,10 +65661,6 @@
 		<default>pu.c:k0:n0:s0:p00:c18</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>18</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -65806,10 +65713,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>pu.c:k0:n0:s0:p00:c19</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>19</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -65865,10 +65768,6 @@
 		<default>pu.eq:k0:n0:s0:p00:c5</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>5</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -65920,10 +65819,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -65980,10 +65875,6 @@
 		<default>pu.c:k0:n0:s0:p00:c20</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>20</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -66038,10 +65929,6 @@
 		<default>pu.c:k0:n0:s0:p00:c21</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>21</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -66093,10 +65980,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -66153,10 +66036,6 @@
 		<default>pu.c:k0:n0:s0:p00:c22</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>22</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -66209,10 +66088,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>pu.c:k0:n0:s0:p00:c23</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>23</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -66268,10 +66143,6 @@
 		<default>pu.eq:k0:n0:s0:p00:c6</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>6</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -66323,10 +66194,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -66383,10 +66250,6 @@
 		<default>pu.c:k0:n0:s0:p00:c24</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>24</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -66441,10 +66304,6 @@
 		<default>pu.c:k0:n0:s0:p00:c25</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>25</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -66496,10 +66355,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -66556,10 +66411,6 @@
 		<default>pu.c:k0:n0:s0:p00:c26</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>26</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -66612,10 +66463,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>pu.c:k0:n0:s0:p00:c27</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>27</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -66671,10 +66518,6 @@
 		<default>pu.eq:k0:n0:s0:p00:c7</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>7</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -66726,10 +66569,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -66786,10 +66625,6 @@
 		<default>pu.c:k0:n0:s0:p00:c28</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>28</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -66844,10 +66679,6 @@
 		<default>pu.c:k0:n0:s0:p00:c29</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>29</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -66899,10 +66730,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -66959,10 +66786,6 @@
 		<default>pu.c:k0:n0:s0:p00:c30</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>30</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -67015,10 +66838,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>pu.c:k0:n0:s0:p00:c31</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>31</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -67191,10 +67010,6 @@
 		<default>pu.mc:k0:n0:s0:p00:c0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
 		<id>FREQ_MC_MHZ</id>
 		<default>0x640</default>
 	</attribute>
@@ -67252,10 +67067,6 @@
 		<default>unknown</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -67306,10 +67117,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -67405,10 +67212,6 @@
 		<default>unknown</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -67462,10 +67265,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>pu.omi:k0:n0:s0:p00:c0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>FRU_PATH</id>
@@ -67551,10 +67350,6 @@
 		<default>pu.omi:k0:n0:s0:p00:c1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>1</default>
-	</attribute>
-	<attribute>
 		<id>FRU_PATH</id>
 		<default></default>
 	</attribute>
@@ -67633,10 +67428,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -67732,10 +67523,6 @@
 		<default>unknown</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -67789,10 +67576,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>pu.omi:k0:n0:s0:p00:c2</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>2</default>
 	</attribute>
 	<attribute>
 		<id>FRU_PATH</id>
@@ -67878,10 +67661,6 @@
 		<default>pu.omi:k0:n0:s0:p00:c3</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>3</default>
-	</attribute>
-	<attribute>
 		<id>FRU_PATH</id>
 		<default></default>
 	</attribute>
@@ -67962,10 +67741,6 @@
 		<default>pu.mc:k0:n0:s0:p00:c1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>1</default>
-	</attribute>
-	<attribute>
 		<id>FREQ_MC_MHZ</id>
 		<default>0x640</default>
 	</attribute>
@@ -68023,10 +67798,6 @@
 		<default>unknown</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -68077,10 +67848,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -68176,10 +67943,6 @@
 		<default>unknown</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -68233,10 +67996,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>pu.omi:k0:n0:s0:p00:c4</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>4</default>
 	</attribute>
 	<attribute>
 		<id>FRU_PATH</id>
@@ -68322,10 +68081,6 @@
 		<default>pu.omi:k0:n0:s0:p00:c5</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>5</default>
-	</attribute>
-	<attribute>
 		<id>FRU_PATH</id>
 		<default></default>
 	</attribute>
@@ -68404,10 +68159,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -68503,10 +68254,6 @@
 		<default>unknown</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -68560,10 +68307,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>pu.omi:k0:n0:s0:p00:c6</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>6</default>
 	</attribute>
 	<attribute>
 		<id>FRU_PATH</id>
@@ -68649,10 +68392,6 @@
 		<default>pu.omi:k0:n0:s0:p00:c7</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>7</default>
-	</attribute>
-	<attribute>
 		<id>FRU_PATH</id>
 		<default></default>
 	</attribute>
@@ -68733,10 +68472,6 @@
 		<default>pu.mc:k0:n0:s0:p00:c2</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>2</default>
-	</attribute>
-	<attribute>
 		<id>FREQ_MC_MHZ</id>
 		<default>0x640</default>
 	</attribute>
@@ -68794,10 +68529,6 @@
 		<default>unknown</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -68848,10 +68579,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -68947,10 +68674,6 @@
 		<default>unknown</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -69004,10 +68727,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>pu.omi:k0:n0:s0:p00:c8</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>8</default>
 	</attribute>
 	<attribute>
 		<id>FRU_PATH</id>
@@ -69093,10 +68812,6 @@
 		<default>pu.omi:k0:n0:s0:p00:c9</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>9</default>
-	</attribute>
-	<attribute>
 		<id>FRU_PATH</id>
 		<default></default>
 	</attribute>
@@ -69175,10 +68890,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -69274,10 +68985,6 @@
 		<default>unknown</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -69331,10 +69038,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>pu.omi:k0:n0:s0:p00:c10</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>10</default>
 	</attribute>
 	<attribute>
 		<id>FRU_PATH</id>
@@ -69420,10 +69123,6 @@
 		<default>pu.omi:k0:n0:s0:p00:c11</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>11</default>
-	</attribute>
-	<attribute>
 		<id>FRU_PATH</id>
 		<default></default>
 	</attribute>
@@ -69504,10 +69203,6 @@
 		<default>pu.mc:k0:n0:s0:p00:c3</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>3</default>
-	</attribute>
-	<attribute>
 		<id>FREQ_MC_MHZ</id>
 		<default>0x640</default>
 	</attribute>
@@ -69565,10 +69260,6 @@
 		<default>unknown</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -69619,10 +69310,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -69718,10 +69405,6 @@
 		<default>unknown</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -69775,10 +69458,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>pu.omi:k0:n0:s0:p00:c12</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>12</default>
 	</attribute>
 	<attribute>
 		<id>FRU_PATH</id>
@@ -69864,10 +69543,6 @@
 		<default>pu.omi:k0:n0:s0:p00:c13</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>13</default>
-	</attribute>
-	<attribute>
 		<id>FRU_PATH</id>
 		<default></default>
 	</attribute>
@@ -69946,10 +69621,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -70045,10 +69716,6 @@
 		<default>unknown</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -70102,10 +69769,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>pu.omi:k0:n0:s0:p00:c14</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>14</default>
 	</attribute>
 	<attribute>
 		<id>FRU_PATH</id>
@@ -70191,10 +69854,6 @@
 		<default>pu.omi:k0:n0:s0:p00:c15</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>15</default>
-	</attribute>
-	<attribute>
 		<id>FRU_PATH</id>
 		<default></default>
 	</attribute>
@@ -70275,10 +69934,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>pu.pec:k0:n0:s0:p00:c0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -70403,10 +70058,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>pu.phb:k0:n0:s0:p00:c0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -70657,10 +70308,6 @@
 		<default>pu.phb:k0:n0:s0:p00:c0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -70854,10 +70501,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>pu.phb:k0:n0:s0:p00:c1</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>1</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -71109,10 +70752,6 @@
 		<default>pu.phb:k0:n0:s0:p00:c1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>1</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -71308,10 +70947,6 @@
 		<default>pu.phb:k0:n0:s0:p00:c2</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>2</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -71505,10 +71140,6 @@
 		<default>pu.pec:k0:n0:s0:p00:c1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>1</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -71631,10 +71262,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>pu.phb:k0:n0:s0:p00:c3</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>3</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -71885,10 +71512,6 @@
 		<default>pu.phb:k0:n0:s0:p00:c3</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>3</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -72082,10 +71705,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>pu.phb:k0:n0:s0:p00:c4</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>4</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -72337,10 +71956,6 @@
 		<default>pu.phb:k0:n0:s0:p00:c4</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>4</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -72536,10 +72151,6 @@
 		<default>pu.phb:k0:n0:s0:p00:c5</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>5</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -72733,10 +72344,6 @@
 		<default>unknown</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -72790,10 +72397,6 @@
 		<default>pu.iohs:k0:n0:s0:p00:c0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
 		<id>FREQ_IOHS_LINK_MHZ</id>
 		<default>32500</default>
 	</attribute>
@@ -72818,6 +72421,10 @@
 		<default></default>
 	</attribute>
 	<attribute>
+		<id>IOHS_SMP9_INTERCONNECT</id>
+		<default>FALSE</default>
+	</attribute>
+	<attribute>
 		<id>IO_IOHS_CHANNEL_LOSS</id>
 		<default>LOW_LOSS</default>
 	</attribute>
@@ -72828,6 +72435,10 @@
 	<attribute>
 		<id>IO_IOHS_PRE2</id>
 		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>IO_IOHS_XTALK</id>
+		<default>NO_XTALK</default>
 	</attribute>
 	<attribute>
 		<id>LINK_SPEED</id>
@@ -73201,10 +72812,6 @@
 		<default>pu.iohs:k0:n0:s0:p00:c1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>1</default>
-	</attribute>
-	<attribute>
 		<id>FREQ_IOHS_LINK_MHZ</id>
 		<default>32500</default>
 	</attribute>
@@ -73229,6 +72836,10 @@
 		<default></default>
 	</attribute>
 	<attribute>
+		<id>IOHS_SMP9_INTERCONNECT</id>
+		<default>FALSE</default>
+	</attribute>
+	<attribute>
 		<id>IO_IOHS_CHANNEL_LOSS</id>
 		<default>LOW_LOSS</default>
 	</attribute>
@@ -73239,6 +72850,10 @@
 	<attribute>
 		<id>IO_IOHS_PRE2</id>
 		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>IO_IOHS_XTALK</id>
+		<default>NO_XTALK</default>
 	</attribute>
 	<attribute>
 		<id>LINK_SPEED</id>
@@ -73406,10 +73021,6 @@
 		<default>pu.pau:k0:n0:s0:p00:c0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -73462,10 +73073,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -73521,10 +73128,6 @@
 		<default>pu.iohs:k0:n0:s0:p00:c2</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>2</default>
-	</attribute>
-	<attribute>
 		<id>FREQ_IOHS_LINK_MHZ</id>
 		<default>32500</default>
 	</attribute>
@@ -73549,6 +73152,10 @@
 		<default></default>
 	</attribute>
 	<attribute>
+		<id>IOHS_SMP9_INTERCONNECT</id>
+		<default>FALSE</default>
+	</attribute>
+	<attribute>
 		<id>IO_IOHS_CHANNEL_LOSS</id>
 		<default>LOW_LOSS</default>
 	</attribute>
@@ -73559,6 +73166,10 @@
 	<attribute>
 		<id>IO_IOHS_PRE2</id>
 		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>IO_IOHS_XTALK</id>
+		<default>NO_XTALK</default>
 	</attribute>
 	<attribute>
 		<id>LINK_SPEED</id>
@@ -73728,10 +73339,6 @@
 		<default>pu.iohs:k0:n0:s0:p00:c3</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>3</default>
-	</attribute>
-	<attribute>
 		<id>FREQ_IOHS_LINK_MHZ</id>
 		<default>32500</default>
 	</attribute>
@@ -73756,6 +73363,10 @@
 		<default></default>
 	</attribute>
 	<attribute>
+		<id>IOHS_SMP9_INTERCONNECT</id>
+		<default>FALSE</default>
+	</attribute>
+	<attribute>
 		<id>IO_IOHS_CHANNEL_LOSS</id>
 		<default>LOW_LOSS</default>
 	</attribute>
@@ -73766,6 +73377,10 @@
 	<attribute>
 		<id>IO_IOHS_PRE2</id>
 		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>IO_IOHS_XTALK</id>
+		<default>NO_XTALK</default>
 	</attribute>
 	<attribute>
 		<id>LINK_SPEED</id>
@@ -73933,10 +73548,6 @@
 		<default>pu.pau:k0:n0:s0:p00:c3</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>3</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -73992,10 +73603,6 @@
 		<default>unknown</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -74049,10 +73656,6 @@
 		<default>pu.iohs:k0:n0:s0:p00:c4</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>4</default>
-	</attribute>
-	<attribute>
 		<id>FREQ_IOHS_LINK_MHZ</id>
 		<default>32500</default>
 	</attribute>
@@ -74077,6 +73680,10 @@
 		<default></default>
 	</attribute>
 	<attribute>
+		<id>IOHS_SMP9_INTERCONNECT</id>
+		<default>FALSE</default>
+	</attribute>
+	<attribute>
 		<id>IO_IOHS_CHANNEL_LOSS</id>
 		<default>LOW_LOSS</default>
 	</attribute>
@@ -74087,6 +73694,10 @@
 	<attribute>
 		<id>IO_IOHS_PRE2</id>
 		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>IO_IOHS_XTALK</id>
+		<default>NO_XTALK</default>
 	</attribute>
 	<attribute>
 		<id>LINK_SPEED</id>
@@ -74256,10 +73867,6 @@
 		<default>pu.iohs:k0:n0:s0:p00:c5</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>5</default>
-	</attribute>
-	<attribute>
 		<id>FREQ_IOHS_LINK_MHZ</id>
 		<default>32500</default>
 	</attribute>
@@ -74284,6 +73891,10 @@
 		<default></default>
 	</attribute>
 	<attribute>
+		<id>IOHS_SMP9_INTERCONNECT</id>
+		<default>FALSE</default>
+	</attribute>
+	<attribute>
 		<id>IO_IOHS_CHANNEL_LOSS</id>
 		<default>LOW_LOSS</default>
 	</attribute>
@@ -74294,6 +73905,10 @@
 	<attribute>
 		<id>IO_IOHS_PRE2</id>
 		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>IO_IOHS_XTALK</id>
+		<default>NO_XTALK</default>
 	</attribute>
 	<attribute>
 		<id>LINK_SPEED</id>
@@ -74461,10 +74076,6 @@
 		<default>pu.pau:k0:n0:s0:p00:c4</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>4</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -74514,10 +74125,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>pu.pau:k0:n0:s0:p00:c5</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -74575,10 +74182,6 @@
 		<default>unknown</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -74632,10 +74235,6 @@
 		<default>pu.iohs:k0:n0:s0:p00:c6</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>6</default>
-	</attribute>
-	<attribute>
 		<id>FREQ_IOHS_LINK_MHZ</id>
 		<default>32500</default>
 	</attribute>
@@ -74660,6 +74259,10 @@
 		<default></default>
 	</attribute>
 	<attribute>
+		<id>IOHS_SMP9_INTERCONNECT</id>
+		<default>FALSE</default>
+	</attribute>
+	<attribute>
 		<id>IO_IOHS_CHANNEL_LOSS</id>
 		<default>LOW_LOSS</default>
 	</attribute>
@@ -74670,6 +74273,10 @@
 	<attribute>
 		<id>IO_IOHS_PRE2</id>
 		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>IO_IOHS_XTALK</id>
+		<default>NO_XTALK</default>
 	</attribute>
 	<attribute>
 		<id>LINK_SPEED</id>
@@ -74839,10 +74446,6 @@
 		<default>pu.iohs:k0:n0:s0:p00:c7</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>7</default>
-	</attribute>
-	<attribute>
 		<id>FREQ_IOHS_LINK_MHZ</id>
 		<default>32500</default>
 	</attribute>
@@ -74867,6 +74470,10 @@
 		<default></default>
 	</attribute>
 	<attribute>
+		<id>IOHS_SMP9_INTERCONNECT</id>
+		<default>FALSE</default>
+	</attribute>
+	<attribute>
 		<id>IO_IOHS_CHANNEL_LOSS</id>
 		<default>LOW_LOSS</default>
 	</attribute>
@@ -74877,6 +74484,10 @@
 	<attribute>
 		<id>IO_IOHS_PRE2</id>
 		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>IO_IOHS_XTALK</id>
+		<default>NO_XTALK</default>
 	</attribute>
 	<attribute>
 		<id>LINK_SPEED</id>
@@ -75044,10 +74655,6 @@
 		<default>pu.pau:k0:n0:s0:p00:c6</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>6</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -75097,10 +74704,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>pu.pau:k0:n0:s0:p00:c7</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>7</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -75154,10 +74757,6 @@
 		<default>unknown</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -75207,10 +74806,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -75264,10 +74859,6 @@
 		<default>unknown</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -75317,10 +74908,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -75374,10 +74961,6 @@
 		<default>unknown</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -75427,10 +75010,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -75484,10 +75063,6 @@
 		<default>unknown</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -75537,10 +75112,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -75594,10 +75165,6 @@
 		<default>unknown</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -75647,10 +75214,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -75704,10 +75267,6 @@
 		<default>unknown</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -75757,10 +75316,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -75814,10 +75369,6 @@
 		<default>unknown</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -75867,10 +75418,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -75924,10 +75471,6 @@
 		<default>unknown</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -75977,10 +75520,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -76034,10 +75573,6 @@
 		<default>unknown</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -76087,10 +75622,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -76144,10 +75675,6 @@
 		<default>unknown</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -76197,10 +75724,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -76254,10 +75777,6 @@
 		<default>unknown</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -76307,10 +75826,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -76364,10 +75879,6 @@
 		<default>unknown</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -76417,10 +75928,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -76474,10 +75981,6 @@
 		<default>unknown</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -76527,10 +76030,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -76584,10 +76083,6 @@
 		<default>unknown</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -76637,10 +76132,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -76694,10 +76185,6 @@
 		<default>unknown</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -76749,10 +76236,6 @@
 		<default>unknown</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>POWER10</default>
 	</attribute>
@@ -76802,10 +76285,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -80101,10 +79580,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>pu:k0:n0:s0:p01</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>1</default>
 	</attribute>
 	<attribute>
 		<id>FREQ_CORE_BOOT_MHZ</id>
@@ -124997,6 +124472,23 @@
 		</default>
 	</attribute>
 	<attribute>
+		<id>EEPROM_VPD_BACKUP_INFO</id>
+		<default>
+				<field><id>i2cMasterPath</id><value>physical:sys-0</value></field>
+				<field><id>port</id><value>0xFF</value></field>
+				<field><id>devAddr</id><value>0xFF</value></field>
+				<field><id>engine</id><value>0xFF</value></field>
+				<field><id>byteAddrOffset</id><value>0xFF</value></field>
+				<field><id>maxMemorySizeKB</id><value>0xFFFFFFFFFFFFFFFF</value></field>
+				<field><id>chipCount</id><value>0xFF</value></field>
+				<field><id>writePageSize</id><value>0xFFFFFFFFFFFFFFFF</value></field>
+				<field><id>writeCycleTime</id><value>0xFFFFFFFFFFFFFFFF</value></field>
+				<field><id>i2cMuxBusSelector</id><value>0xFF</value></field>
+				<field><id>i2cMuxPath</id><value>physical:sys-0</value></field>
+				<field><id>eepromContentType</id><value>0x4</value></field>
+		</default>
+	</attribute>
+	<attribute>
 		<id>EEPROM_VPD_PRIMARY_INFO</id>
 		<default>
 				<field><id>i2cMasterPath</id><value></value></field>
@@ -125016,10 +124508,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>FRU_ID</id>
@@ -125129,6 +124617,27 @@
 		<default>CHIP</default>
 	</attribute>
 	<attribute>
+		<id>CLOCKSTOP_ON_XSTOP</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>EEPROM_VPD_BACKUP_INFO</id>
+		<default>
+				<field><id>i2cMasterPath</id><value>physical:sys-0</value></field>
+				<field><id>port</id><value>0xFF</value></field>
+				<field><id>devAddr</id><value>0xFF</value></field>
+				<field><id>engine</id><value>0xFF</value></field>
+				<field><id>byteAddrOffset</id><value>0xFF</value></field>
+				<field><id>maxMemorySizeKB</id><value>0xFFFFFFFFFFFFFFFF</value></field>
+				<field><id>chipCount</id><value>0xFF</value></field>
+				<field><id>writePageSize</id><value>0xFFFFFFFFFFFFFFFF</value></field>
+				<field><id>writeCycleTime</id><value>0xFFFFFFFFFFFFFFFF</value></field>
+				<field><id>i2cMuxBusSelector</id><value>0xFF</value></field>
+				<field><id>i2cMuxPath</id><value>physical:sys-0</value></field>
+				<field><id>eepromContentType</id><value>0xFFFFFFFF</value></field>
+		</default>
+	</attribute>
+	<attribute>
 		<id>EEPROM_VPD_PRIMARY_INFO</id>
 		<default>
 				<field><id>i2cMasterPath</id><value></value></field>
@@ -125161,10 +124670,6 @@
 		<default>unknown</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>FRU_ID</id>
 		<default>0</default>
 	</attribute>
@@ -125174,6 +124679,10 @@
 				<field><id>flipPort</id><value></value></field>
 				<field><id>reserved</id><value></value></field>
 		</default>
+	</attribute>
+	<attribute>
+		<id>IO_TANK_PLL_BYPASS</id>
+		<default></default>
 	</attribute>
 	<attribute>
 		<id>LOCATION_CODE</id>
@@ -125267,10 +124776,6 @@
 		<default>unknown</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>FRU_PATH</id>
 		<default></default>
 	</attribute>
@@ -125352,10 +124857,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -139727,10 +139228,6 @@
 		<default>unknown</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>I2C_DEV_TYPE</id>
 		<default>0xFF</default>
 	</attribute>
@@ -147167,10 +146664,6 @@
 		<default>unknown</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>I2C_DEV_TYPE</id>
 		<default>0xFF</default>
 	</attribute>
@@ -147261,10 +146754,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>I2C_DEV_TYPE</id>
@@ -147359,10 +146848,6 @@
 		<default>unknown</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>I2C_DEV_TYPE</id>
 		<default>0xFF</default>
 	</attribute>
@@ -147453,10 +146938,6 @@
 	<attribute>
 		<id>FAPI_NAME</id>
 		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>I2C_DEV_TYPE</id>

--- a/Rainier-4U-MRW.xml
+++ b/Rainier-4U-MRW.xml
@@ -1579,6 +1579,17 @@
 		</enumerator>
 </enumerationType>
 <enumerationType>
+	<id>IOHS_SMP9_INTERCONNECT</id>
+		<enumerator>
+		<name>TRUE</name>
+		<value>0x1</value>
+		</enumerator>
+		<enumerator>
+		<name>FALSE</name>
+		<value>0x0</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
 	<id>IOHS_SPREAD_SPECTRUM</id>
 		<enumerator>
 		<name>DISABLED</name>
@@ -2710,6 +2721,10 @@
 		<enumerator>
 		<name>EXPLORER</name>
 		<value>0x8</value>
+		</enumerator>
+		<enumerator>
+		<name>ODYSSEY</name>
+		<value>0xB</value>
 		</enumerator>
 		<enumerator>
 		<name>NONE</name>
@@ -50128,6 +50143,18 @@
 		<default>NONE</default>
 	</attribute>
 	<attribute>
+		<id>INDEX_N_BULK_POWER_LIMIT_WATTS</id>
+		<default>1120,930,2260,1880,1500,3020,0,0,0,0,0,0</default>
+	</attribute>
+	<attribute>
+		<id>INDEX_N_PLUS_ONE_BULK_POWER_LIMIT_WATTS</id>
+		<default>1500,1250,3000,2500,2000,4000,0,0,0,0,0,0</default>
+	</attribute>
+	<attribute>
+		<id>INDEX_POWER_LIMIT_CONFIG</id>
+		<default>0x2B1D0202,0x2B1D0102,0x2B1D0204,0x2B1D0104,0x2B1E0202,0x2B1E0204,0,0,0,0,0,0</default>
+	</attribute>
+	<attribute>
 		<id>IPMI_SENSORS</id>
 		<default></default>
 	</attribute>
@@ -51259,7 +51286,7 @@
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
-		<default></default>
+		<default>null</default>
 	</attribute>
 	<attribute>
 		<id>MRW_TYPE</id>
@@ -92654,6 +92681,10 @@
 		<default></default>
 	</attribute>
 	<attribute>
+		<id>IOHS_SMP9_INTERCONNECT</id>
+		<default>FALSE</default>
+	</attribute>
+	<attribute>
 		<id>IO_IOHS_CHANNEL_LOSS</id>
 		<default>LOW_LOSS</default>
 	</attribute>
@@ -93065,6 +93096,10 @@
 		<default></default>
 	</attribute>
 	<attribute>
+		<id>IOHS_SMP9_INTERCONNECT</id>
+		<default>FALSE</default>
+	</attribute>
+	<attribute>
 		<id>IO_IOHS_CHANNEL_LOSS</id>
 		<default>LOW_LOSS</default>
 	</attribute>
@@ -93377,6 +93412,10 @@
 		<default></default>
 	</attribute>
 	<attribute>
+		<id>IOHS_SMP9_INTERCONNECT</id>
+		<default>FALSE</default>
+	</attribute>
+	<attribute>
 		<id>IO_IOHS_CHANNEL_LOSS</id>
 		<default>LOW_LOSS</default>
 	</attribute>
@@ -93582,6 +93621,10 @@
 	<attribute>
 		<id>IOHS_LINK_SPLIT</id>
 		<default></default>
+	</attribute>
+	<attribute>
+		<id>IOHS_SMP9_INTERCONNECT</id>
+		<default>FALSE</default>
 	</attribute>
 	<attribute>
 		<id>IO_IOHS_CHANNEL_LOSS</id>
@@ -93897,6 +93940,10 @@
 		<default></default>
 	</attribute>
 	<attribute>
+		<id>IOHS_SMP9_INTERCONNECT</id>
+		<default>FALSE</default>
+	</attribute>
+	<attribute>
 		<id>IO_IOHS_CHANNEL_LOSS</id>
 		<default>LOW_LOSS</default>
 	</attribute>
@@ -94102,6 +94149,10 @@
 	<attribute>
 		<id>IOHS_LINK_SPLIT</id>
 		<default></default>
+	</attribute>
+	<attribute>
+		<id>IOHS_SMP9_INTERCONNECT</id>
+		<default>FALSE</default>
 	</attribute>
 	<attribute>
 		<id>IO_IOHS_CHANNEL_LOSS</id>
@@ -94468,6 +94519,10 @@
 		<default></default>
 	</attribute>
 	<attribute>
+		<id>IOHS_SMP9_INTERCONNECT</id>
+		<default>FALSE</default>
+	</attribute>
+	<attribute>
 		<id>IO_IOHS_CHANNEL_LOSS</id>
 		<default>LOW_LOSS</default>
 	</attribute>
@@ -94673,6 +94728,10 @@
 	<attribute>
 		<id>IOHS_LINK_SPLIT</id>
 		<default></default>
+	</attribute>
+	<attribute>
+		<id>IOHS_SMP9_INTERCONNECT</id>
+		<default>FALSE</default>
 	</attribute>
 	<attribute>
 		<id>IO_IOHS_CHANNEL_LOSS</id>
@@ -144756,6 +144815,23 @@
 		</default>
 	</attribute>
 	<attribute>
+		<id>EEPROM_VPD_BACKUP_INFO</id>
+		<default>
+				<field><id>i2cMasterPath</id><value>physical:sys-0</value></field>
+				<field><id>port</id><value>0xFF</value></field>
+				<field><id>devAddr</id><value>0xFF</value></field>
+				<field><id>engine</id><value>0xFF</value></field>
+				<field><id>byteAddrOffset</id><value>0xFF</value></field>
+				<field><id>maxMemorySizeKB</id><value>0xFFFFFFFFFFFFFFFF</value></field>
+				<field><id>chipCount</id><value>0xFF</value></field>
+				<field><id>writePageSize</id><value>0xFFFFFFFFFFFFFFFF</value></field>
+				<field><id>writeCycleTime</id><value>0xFFFFFFFFFFFFFFFF</value></field>
+				<field><id>i2cMuxBusSelector</id><value>0xFF</value></field>
+				<field><id>i2cMuxPath</id><value>physical:sys-0</value></field>
+				<field><id>eepromContentType</id><value>0x4</value></field>
+		</default>
+	</attribute>
+	<attribute>
 		<id>EEPROM_VPD_PRIMARY_INFO</id>
 		<default>
 				<field><id>i2cMasterPath</id><value></value></field>
@@ -144887,6 +144963,23 @@
 	<attribute>
 		<id>CLOCKSTOP_ON_XSTOP</id>
 		<default></default>
+	</attribute>
+	<attribute>
+		<id>EEPROM_VPD_BACKUP_INFO</id>
+		<default>
+				<field><id>i2cMasterPath</id><value>physical:sys-0</value></field>
+				<field><id>port</id><value>0xFF</value></field>
+				<field><id>devAddr</id><value>0xFF</value></field>
+				<field><id>engine</id><value>0xFF</value></field>
+				<field><id>byteAddrOffset</id><value>0xFF</value></field>
+				<field><id>maxMemorySizeKB</id><value>0xFFFFFFFFFFFFFFFF</value></field>
+				<field><id>chipCount</id><value>0xFF</value></field>
+				<field><id>writePageSize</id><value>0xFFFFFFFFFFFFFFFF</value></field>
+				<field><id>writeCycleTime</id><value>0xFFFFFFFFFFFFFFFF</value></field>
+				<field><id>i2cMuxBusSelector</id><value>0xFF</value></field>
+				<field><id>i2cMuxPath</id><value>physical:sys-0</value></field>
+				<field><id>eepromContentType</id><value>0xFFFFFFFF</value></field>
+		</default>
 	</attribute>
 	<attribute>
 		<id>EEPROM_VPD_PRIMARY_INFO</id>


### PR DESCRIPTION
This is for Sheldon B to review as it relates to LI 14L for Rainier PSU pcap support. 

Three new attributes were added:
       o INDEX_POWER_LIMIT_CONFIG
       o INDEX_N_PLUS_ONE_BULK_POWER_LIMIT_WATTS
       o INDEX_N_BULK_POWER_LIMIT_WATTS

This PR adds valid values to the Rainier 2U and 4U MRW files to support them. 

This is approved for FW1030.20 per LI.
