### PR TITLE
Added support for Odyssey and fixed value for EXTERNAL_VRM_STEPSIZE

### DIFF
--- a/Rainier-2U-MRW.xml
+++ b/Rainier-2U-MRW.xml
@@ -160,6 +160,10 @@
 		<value>16</value>
 		</enumerator>
 		<enumerator>
+		<name>DDR5</name>
+		<value>30</value>
+		</enumerator>
+		<enumerator>
 		<name>DDR4</name>
 		<value>9</value>
 		</enumerator>
@@ -389,25 +393,6 @@
 		<enumerator>
 		<name>SP</name>
 		<value>10</value>
-		</enumerator>
-</enumerationType>
-<enumerationType>
-	<id>CLOCKSTOP_ON_XSTOP</id>
-		<enumerator>
-		<name>DISABLED</name>
-		<value>0x00</value>
-		</enumerator>
-		<enumerator>
-		<name>STOP_ON_XSTOP_AND_SPATTN</name>
-		<value>0x5B</value>
-		</enumerator>
-		<enumerator>
-		<name>STOP_ON_XSTOP</name>
-		<value>0x7B</value>
-		</enumerator>
-		<enumerator>
-		<name>STOP_ON_STAGED_XSTOP</name>
-		<value>0xFD</value>
 		</enumerator>
 </enumerationType>
 <enumerationType>
@@ -2860,15 +2845,15 @@
 	<id>OMI_RX_LANES</id>
 		<enumerator>
 		<name>X8</name>
-		<value>0xFF</value>
+		<value>0xFF000000</value>
 		</enumerator>
 		<enumerator>
 		<name>X2</name>
-		<value>0x81</value>
+		<value>0x81000000</value>
 		</enumerator>
 		<enumerator>
 		<name>X4</name>
-		<value>0xA5</value>
+		<value>0xA5000000</value>
 		</enumerator>
 </enumerationType>
 <enumerationType>
@@ -2886,15 +2871,15 @@
 	<id>OMI_TX_LANES</id>
 		<enumerator>
 		<name>X8</name>
-		<value>0xFF</value>
+		<value>0xFF000000</value>
 		</enumerator>
 		<enumerator>
 		<name>X2</name>
-		<value>0x81</value>
+		<value>0x81000000</value>
 		</enumerator>
 		<enumerator>
 		<name>X4</name>
-		<value>0xA5</value>
+		<value>0xA5000000</value>
 		</enumerator>
 </enumerationType>
 <enumerationType>
@@ -13354,9 +13339,13 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-0/ddimm-0/ddr4</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-0/ddimm-0/ddr5</id>
 	<property>
 	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -13383,7 +13372,14 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-0/ddimm-0/ocmb/i2c-ocmb</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-0/ddimm-0/ocmb/i2c-ocmb-master</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>OUT</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-0/ddimm-0/ocmb/i2c-ocmb-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -13428,9 +13424,35 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-0/ddimm-0/ocmb/mem_port</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-0/ddimm-0/ocmb/i2c-ts2</id>
 	<property>
 	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0x34</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-0/ddimm-0/ocmb/mem_port0</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-0/ddimm-0/ocmb/mem_port1</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -13449,7 +13471,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0x90</value>
+	<value>0xCE</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -13508,7 +13530,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0xC0</value>
+	<value>0xB4</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -13549,7 +13571,7 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-0/ddimm-0/spd/i2c-slave</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-0/ddimm-0/spdA/i2c-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -13557,6 +13579,21 @@
 	<property>
 	<id>I2C_ADDRESS</id>
 	<value>0xA0</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value>24c32</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-0/ddimm-0/spdB/i2c-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0xA2</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -13586,9 +13623,13 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-1/ddimm-0/ddr4</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-1/ddimm-0/ddr5</id>
 	<property>
 	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -13615,7 +13656,14 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-1/ddimm-0/ocmb/i2c-ocmb</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-1/ddimm-0/ocmb/i2c-ocmb-master</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>OUT</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-1/ddimm-0/ocmb/i2c-ocmb-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -13660,9 +13708,35 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-1/ddimm-0/ocmb/mem_port</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-1/ddimm-0/ocmb/i2c-ts2</id>
 	<property>
 	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0x34</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-1/ddimm-0/ocmb/mem_port0</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-1/ddimm-0/ocmb/mem_port1</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -13681,7 +13755,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0x90</value>
+	<value>0xCE</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -13729,7 +13803,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0xC0</value>
+	<value>0xB4</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -13770,7 +13844,7 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-1/ddimm-0/spd/i2c-slave</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-1/ddimm-0/spdA/i2c-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -13785,6 +13859,21 @@
 	</property>
 </globalSetting>
 <globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-1/ddimm-0/spdB/i2c-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0xA2</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value>24c32</value>
+	</property>
+</globalSetting>
+<globalSetting>
 	<id>/sys-0/node-0/nisqually-0/ddimm-connector-10</id>
 	<property>
 	<id>CONNECTOR_TYPE</id>
@@ -13792,9 +13881,13 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-10/ddimm-0/ddr4</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-10/ddimm-0/ddr5</id>
 	<property>
 	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -13821,7 +13914,14 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-10/ddimm-0/ocmb/i2c-ocmb</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-10/ddimm-0/ocmb/i2c-ocmb-master</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>OUT</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-10/ddimm-0/ocmb/i2c-ocmb-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -13866,9 +13966,35 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-10/ddimm-0/ocmb/mem_port</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-10/ddimm-0/ocmb/i2c-ts2</id>
 	<property>
 	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0x34</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-10/ddimm-0/ocmb/mem_port0</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-10/ddimm-0/ocmb/mem_port1</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -13887,7 +14013,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0x90</value>
+	<value>0xCE</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -13935,7 +14061,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0xC0</value>
+	<value>0xB4</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -13976,7 +14102,7 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-10/ddimm-0/spd/i2c-slave</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-10/ddimm-0/spdA/i2c-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -13984,6 +14110,21 @@
 	<property>
 	<id>I2C_ADDRESS</id>
 	<value>0xA0</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value>24c32</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-10/ddimm-0/spdB/i2c-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0xA2</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -14013,9 +14154,13 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-11/ddimm-0/ddr4</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-11/ddimm-0/ddr5</id>
 	<property>
 	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -14042,7 +14187,14 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-11/ddimm-0/ocmb/i2c-ocmb</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-11/ddimm-0/ocmb/i2c-ocmb-master</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>OUT</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-11/ddimm-0/ocmb/i2c-ocmb-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -14087,9 +14239,35 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-11/ddimm-0/ocmb/mem_port</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-11/ddimm-0/ocmb/i2c-ts2</id>
 	<property>
 	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0x34</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-11/ddimm-0/ocmb/mem_port0</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-11/ddimm-0/ocmb/mem_port1</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -14108,7 +14286,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0x90</value>
+	<value>0xCE</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -14156,7 +14334,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0xC0</value>
+	<value>0xB4</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -14197,7 +14375,7 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-11/ddimm-0/spd/i2c-slave</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-11/ddimm-0/spdA/i2c-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -14205,6 +14383,21 @@
 	<property>
 	<id>I2C_ADDRESS</id>
 	<value>0xA0</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value>24c32</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-11/ddimm-0/spdB/i2c-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0xA2</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -14230,9 +14423,13 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-12/ddimm-0/ddr4</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-12/ddimm-0/ddr5</id>
 	<property>
 	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -14259,7 +14456,14 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-12/ddimm-0/ocmb/i2c-ocmb</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-12/ddimm-0/ocmb/i2c-ocmb-master</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>OUT</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-12/ddimm-0/ocmb/i2c-ocmb-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -14304,9 +14508,39 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-12/ddimm-0/ocmb/mem_port</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-12/ddimm-0/ocmb/i2c-ts2</id>
 	<property>
 	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0x34</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-12/ddimm-0/ocmb/mem_port0</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-12/ddimm-0/ocmb/mem_port1</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -14325,7 +14559,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0x90</value>
+	<value>0xCE</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -14384,7 +14618,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0xC0</value>
+	<value>0xB4</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -14425,7 +14659,7 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-12/ddimm-0/spd/i2c-slave</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-12/ddimm-0/spdA/i2c-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -14433,6 +14667,21 @@
 	<property>
 	<id>I2C_ADDRESS</id>
 	<value>0xA0</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value>24c32</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-12/ddimm-0/spdB/i2c-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0xA2</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -14462,9 +14711,13 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-13/ddimm-0/ddr4</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-13/ddimm-0/ddr5</id>
 	<property>
 	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -14491,7 +14744,14 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-13/ddimm-0/ocmb/i2c-ocmb</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-13/ddimm-0/ocmb/i2c-ocmb-master</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>OUT</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-13/ddimm-0/ocmb/i2c-ocmb-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -14536,9 +14796,35 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-13/ddimm-0/ocmb/mem_port</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-13/ddimm-0/ocmb/i2c-ts2</id>
 	<property>
 	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0x34</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-13/ddimm-0/ocmb/mem_port0</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-13/ddimm-0/ocmb/mem_port1</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -14557,7 +14843,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0x90</value>
+	<value>0xCE</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -14605,7 +14891,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0xC0</value>
+	<value>0xB4</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -14646,7 +14932,7 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-13/ddimm-0/spd/i2c-slave</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-13/ddimm-0/spdA/i2c-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -14661,6 +14947,21 @@
 	</property>
 </globalSetting>
 <globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-13/ddimm-0/spdB/i2c-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0xA2</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value>24c32</value>
+	</property>
+</globalSetting>
+<globalSetting>
 	<id>/sys-0/node-0/nisqually-0/ddimm-connector-14</id>
 	<property>
 	<id>CONNECTOR_TYPE</id>
@@ -14668,9 +14969,13 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-14/ddimm-0/ddr4</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-14/ddimm-0/ddr5</id>
 	<property>
 	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -14697,7 +15002,14 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-14/ddimm-0/ocmb/i2c-ocmb</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-14/ddimm-0/ocmb/i2c-ocmb-master</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>OUT</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-14/ddimm-0/ocmb/i2c-ocmb-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -14742,9 +15054,35 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-14/ddimm-0/ocmb/mem_port</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-14/ddimm-0/ocmb/i2c-ts2</id>
 	<property>
 	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0x34</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-14/ddimm-0/ocmb/mem_port0</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-14/ddimm-0/ocmb/mem_port1</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -14763,7 +15101,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0x90</value>
+	<value>0xCE</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -14811,7 +15149,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0xC0</value>
+	<value>0xB4</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -14852,7 +15190,7 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-14/ddimm-0/spd/i2c-slave</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-14/ddimm-0/spdA/i2c-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -14860,6 +15198,21 @@
 	<property>
 	<id>I2C_ADDRESS</id>
 	<value>0xA0</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value>24c32</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-14/ddimm-0/spdB/i2c-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0xA2</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -14889,9 +15242,13 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-15/ddimm-0/ddr4</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-15/ddimm-0/ddr5</id>
 	<property>
 	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -14918,7 +15275,14 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-15/ddimm-0/ocmb/i2c-ocmb</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-15/ddimm-0/ocmb/i2c-ocmb-master</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>OUT</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-15/ddimm-0/ocmb/i2c-ocmb-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -14963,9 +15327,35 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-15/ddimm-0/ocmb/mem_port</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-15/ddimm-0/ocmb/i2c-ts2</id>
 	<property>
 	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0x34</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-15/ddimm-0/ocmb/mem_port0</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-15/ddimm-0/ocmb/mem_port1</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -14984,7 +15374,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0x90</value>
+	<value>0xCE</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -15032,7 +15422,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0xC0</value>
+	<value>0xB4</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -15073,7 +15463,7 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-15/ddimm-0/spd/i2c-slave</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-15/ddimm-0/spdA/i2c-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -15088,6 +15478,21 @@
 	</property>
 </globalSetting>
 <globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-15/ddimm-0/spdB/i2c-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0xA2</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value>24c32</value>
+	</property>
+</globalSetting>
+<globalSetting>
 	<id>/sys-0/node-0/nisqually-0/ddimm-connector-16</id>
 	<property>
 	<id>CONNECTOR_TYPE</id>
@@ -15095,9 +15500,13 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-16/ddimm-0/ddr4</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-16/ddimm-0/ddr5</id>
 	<property>
 	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -15124,7 +15533,14 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-16/ddimm-0/ocmb/i2c-ocmb</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-16/ddimm-0/ocmb/i2c-ocmb-master</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>OUT</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-16/ddimm-0/ocmb/i2c-ocmb-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -15169,9 +15585,35 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-16/ddimm-0/ocmb/mem_port</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-16/ddimm-0/ocmb/i2c-ts2</id>
 	<property>
 	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0x34</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-16/ddimm-0/ocmb/mem_port0</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-16/ddimm-0/ocmb/mem_port1</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -15190,7 +15632,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0x90</value>
+	<value>0xCE</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -15238,7 +15680,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0xC0</value>
+	<value>0xB4</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -15279,7 +15721,7 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-16/ddimm-0/spd/i2c-slave</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-16/ddimm-0/spdA/i2c-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -15287,6 +15729,21 @@
 	<property>
 	<id>I2C_ADDRESS</id>
 	<value>0xA0</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value>24c32</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-16/ddimm-0/spdB/i2c-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0xA2</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -15310,11 +15767,23 @@
 	<id>FRU_NAME</id>
 	<value></value>
 	</property>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
+	<value></value>
+	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-17/ddimm-0/ddr4</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-17/ddimm-0/ddr5</id>
 	<property>
 	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -15341,7 +15810,14 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-17/ddimm-0/ocmb/i2c-ocmb</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-17/ddimm-0/ocmb/i2c-ocmb-master</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>OUT</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-17/ddimm-0/ocmb/i2c-ocmb-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -15386,9 +15862,39 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-17/ddimm-0/ocmb/mem_port</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-17/ddimm-0/ocmb/i2c-ts2</id>
 	<property>
 	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0x34</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-17/ddimm-0/ocmb/mem_port0</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-17/ddimm-0/ocmb/mem_port1</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -15407,7 +15913,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0x90</value>
+	<value>0xCE</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -15455,7 +15961,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0xC0</value>
+	<value>0xB4</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -15496,7 +16002,7 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-17/ddimm-0/spd/i2c-slave</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-17/ddimm-0/spdA/i2c-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -15511,6 +16017,21 @@
 	</property>
 </globalSetting>
 <globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-17/ddimm-0/spdB/i2c-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0xA2</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value>24c32</value>
+	</property>
+</globalSetting>
+<globalSetting>
 	<id>/sys-0/node-0/nisqually-0/ddimm-connector-18</id>
 	<property>
 	<id>CONNECTOR_TYPE</id>
@@ -15518,9 +16039,13 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-18/ddimm-0/ddr4</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-18/ddimm-0/ddr5</id>
 	<property>
 	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -15547,7 +16072,14 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-18/ddimm-0/ocmb/i2c-ocmb</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-18/ddimm-0/ocmb/i2c-ocmb-master</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>OUT</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-18/ddimm-0/ocmb/i2c-ocmb-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -15592,9 +16124,35 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-18/ddimm-0/ocmb/mem_port</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-18/ddimm-0/ocmb/i2c-ts2</id>
 	<property>
 	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0x34</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-18/ddimm-0/ocmb/mem_port0</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-18/ddimm-0/ocmb/mem_port1</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -15613,7 +16171,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0x90</value>
+	<value>0xCE</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -15661,7 +16219,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0xC0</value>
+	<value>0xB4</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -15702,7 +16260,7 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-18/ddimm-0/spd/i2c-slave</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-18/ddimm-0/spdA/i2c-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -15717,6 +16275,21 @@
 	</property>
 </globalSetting>
 <globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-18/ddimm-0/spdB/i2c-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0xA2</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value>24c32</value>
+	</property>
+</globalSetting>
+<globalSetting>
 	<id>/sys-0/node-0/nisqually-0/ddimm-connector-19</id>
 	<property>
 	<id>CONNECTOR_TYPE</id>
@@ -15724,9 +16297,13 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-19/ddimm-0/ddr4</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-19/ddimm-0/ddr5</id>
 	<property>
 	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -15753,7 +16330,14 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-19/ddimm-0/ocmb/i2c-ocmb</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-19/ddimm-0/ocmb/i2c-ocmb-master</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>OUT</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-19/ddimm-0/ocmb/i2c-ocmb-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -15798,9 +16382,35 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-19/ddimm-0/ocmb/mem_port</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-19/ddimm-0/ocmb/i2c-ts2</id>
 	<property>
 	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0x34</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-19/ddimm-0/ocmb/mem_port0</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-19/ddimm-0/ocmb/mem_port1</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -15819,7 +16429,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0x90</value>
+	<value>0xCE</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -15867,7 +16477,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0xC0</value>
+	<value>0xB4</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -15908,7 +16518,7 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-19/ddimm-0/spd/i2c-slave</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-19/ddimm-0/spdA/i2c-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -15916,6 +16526,21 @@
 	<property>
 	<id>I2C_ADDRESS</id>
 	<value>0xA0</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value>24c32</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-19/ddimm-0/spdB/i2c-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0xA2</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -15945,9 +16570,13 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-2/ddimm-0/ddr4</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-2/ddimm-0/ddr5</id>
 	<property>
 	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -15974,7 +16603,14 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-2/ddimm-0/ocmb/i2c-ocmb</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-2/ddimm-0/ocmb/i2c-ocmb-master</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>OUT</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-2/ddimm-0/ocmb/i2c-ocmb-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -16019,9 +16655,35 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-2/ddimm-0/ocmb/mem_port</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-2/ddimm-0/ocmb/i2c-ts2</id>
 	<property>
 	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0x34</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-2/ddimm-0/ocmb/mem_port0</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-2/ddimm-0/ocmb/mem_port1</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -16040,7 +16702,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0x90</value>
+	<value>0xCE</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -16088,7 +16750,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0xC0</value>
+	<value>0xB4</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -16129,7 +16791,7 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-2/ddimm-0/spd/i2c-slave</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-2/ddimm-0/spdA/i2c-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -16137,6 +16799,21 @@
 	<property>
 	<id>I2C_ADDRESS</id>
 	<value>0xA0</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value>24c32</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-2/ddimm-0/spdB/i2c-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0xA2</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -16166,9 +16843,13 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-20/ddimm-0/ddr4</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-20/ddimm-0/ddr5</id>
 	<property>
 	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -16195,7 +16876,14 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-20/ddimm-0/ocmb/i2c-ocmb</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-20/ddimm-0/ocmb/i2c-ocmb-master</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>OUT</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-20/ddimm-0/ocmb/i2c-ocmb-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -16240,9 +16928,35 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-20/ddimm-0/ocmb/mem_port</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-20/ddimm-0/ocmb/i2c-ts2</id>
 	<property>
 	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0x34</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-20/ddimm-0/ocmb/mem_port0</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-20/ddimm-0/ocmb/mem_port1</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -16261,7 +16975,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0x90</value>
+	<value>0xCE</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -16309,7 +17023,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0xC0</value>
+	<value>0xB4</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -16350,7 +17064,7 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-20/ddimm-0/spd/i2c-slave</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-20/ddimm-0/spdA/i2c-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -16358,6 +17072,21 @@
 	<property>
 	<id>I2C_ADDRESS</id>
 	<value>0xA0</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value>24c32</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-20/ddimm-0/spdB/i2c-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0xA2</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -16383,9 +17112,13 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-21/ddimm-0/ddr4</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-21/ddimm-0/ddr5</id>
 	<property>
 	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -16412,7 +17145,14 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-21/ddimm-0/ocmb/i2c-ocmb</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-21/ddimm-0/ocmb/i2c-ocmb-master</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>OUT</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-21/ddimm-0/ocmb/i2c-ocmb-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -16457,9 +17197,35 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-21/ddimm-0/ocmb/mem_port</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-21/ddimm-0/ocmb/i2c-ts2</id>
 	<property>
 	<id>DIRECTION</id>
+	<value>NA</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0x34</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-21/ddimm-0/ocmb/mem_port0</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-21/ddimm-0/ocmb/mem_port1</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -16478,7 +17244,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0x90</value>
+	<value>0xCE</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -16526,7 +17292,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0xC0</value>
+	<value>0xB4</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -16567,7 +17333,7 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-21/ddimm-0/spd/i2c-slave</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-21/ddimm-0/spdA/i2c-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -16575,6 +17341,21 @@
 	<property>
 	<id>I2C_ADDRESS</id>
 	<value>0xA0</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value>24c32</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-21/ddimm-0/spdB/i2c-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0xA2</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -16600,9 +17381,13 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-22/ddimm-0/ddr4</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-22/ddimm-0/ddr5</id>
 	<property>
 	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -16629,7 +17414,14 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-22/ddimm-0/ocmb/i2c-ocmb</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-22/ddimm-0/ocmb/i2c-ocmb-master</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>OUT</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-22/ddimm-0/ocmb/i2c-ocmb-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -16674,9 +17466,35 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-22/ddimm-0/ocmb/mem_port</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-22/ddimm-0/ocmb/i2c-ts2</id>
 	<property>
 	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0x34</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-22/ddimm-0/ocmb/mem_port0</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-22/ddimm-0/ocmb/mem_port1</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -16695,7 +17513,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0x90</value>
+	<value>0xCE</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -16743,7 +17561,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0xC0</value>
+	<value>0xB4</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -16784,7 +17602,7 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-22/ddimm-0/spd/i2c-slave</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-22/ddimm-0/spdA/i2c-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -16792,6 +17610,21 @@
 	<property>
 	<id>I2C_ADDRESS</id>
 	<value>0xA0</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value>24c32</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-22/ddimm-0/spdB/i2c-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0xA2</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -16821,9 +17654,13 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-23/ddimm-0/ddr4</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-23/ddimm-0/ddr5</id>
 	<property>
 	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -16850,7 +17687,14 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-23/ddimm-0/ocmb/i2c-ocmb</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-23/ddimm-0/ocmb/i2c-ocmb-master</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>OUT</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-23/ddimm-0/ocmb/i2c-ocmb-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -16895,9 +17739,35 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-23/ddimm-0/ocmb/mem_port</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-23/ddimm-0/ocmb/i2c-ts2</id>
 	<property>
 	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0x34</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-23/ddimm-0/ocmb/mem_port0</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-23/ddimm-0/ocmb/mem_port1</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -16916,7 +17786,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0x90</value>
+	<value>0xCE</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -16964,7 +17834,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0xC0</value>
+	<value>0xB4</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -17005,7 +17875,7 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-23/ddimm-0/spd/i2c-slave</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-23/ddimm-0/spdA/i2c-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -17020,6 +17890,21 @@
 	</property>
 </globalSetting>
 <globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-23/ddimm-0/spdB/i2c-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0xA2</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value>24c32</value>
+	</property>
+</globalSetting>
+<globalSetting>
 	<id>/sys-0/node-0/nisqually-0/ddimm-connector-24</id>
 	<property>
 	<id>CONNECTOR_TYPE</id>
@@ -17027,9 +17912,13 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-24/ddimm-0/ddr4</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-24/ddimm-0/ddr5</id>
 	<property>
 	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -17056,7 +17945,14 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-24/ddimm-0/ocmb/i2c-ocmb</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-24/ddimm-0/ocmb/i2c-ocmb-master</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>OUT</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-24/ddimm-0/ocmb/i2c-ocmb-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -17101,9 +17997,39 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-24/ddimm-0/ocmb/mem_port</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-24/ddimm-0/ocmb/i2c-ts2</id>
 	<property>
 	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0x34</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-24/ddimm-0/ocmb/mem_port0</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-24/ddimm-0/ocmb/mem_port1</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -17122,7 +18048,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0x90</value>
+	<value>0xCE</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -17170,7 +18096,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0xC0</value>
+	<value>0xB4</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -17211,7 +18137,7 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-24/ddimm-0/spd/i2c-slave</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-24/ddimm-0/spdA/i2c-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -17219,6 +18145,21 @@
 	<property>
 	<id>I2C_ADDRESS</id>
 	<value>0xA0</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value>24c32</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-24/ddimm-0/spdB/i2c-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0xA2</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -17244,9 +18185,13 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-25/ddimm-0/ddr4</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-25/ddimm-0/ddr5</id>
 	<property>
 	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -17273,7 +18218,14 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-25/ddimm-0/ocmb/i2c-ocmb</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-25/ddimm-0/ocmb/i2c-ocmb-master</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>OUT</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-25/ddimm-0/ocmb/i2c-ocmb-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -17318,9 +18270,35 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-25/ddimm-0/ocmb/mem_port</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-25/ddimm-0/ocmb/i2c-ts2</id>
 	<property>
 	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0x34</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-25/ddimm-0/ocmb/mem_port0</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-25/ddimm-0/ocmb/mem_port1</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -17339,7 +18317,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0x90</value>
+	<value>0xCE</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -17387,7 +18365,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0xC0</value>
+	<value>0xB4</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -17428,7 +18406,7 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-25/ddimm-0/spd/i2c-slave</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-25/ddimm-0/spdA/i2c-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -17436,6 +18414,21 @@
 	<property>
 	<id>I2C_ADDRESS</id>
 	<value>0xA0</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value>24c32</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-25/ddimm-0/spdB/i2c-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0xA2</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -17461,9 +18454,13 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-26/ddimm-0/ddr4</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-26/ddimm-0/ddr5</id>
 	<property>
 	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -17490,7 +18487,14 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-26/ddimm-0/ocmb/i2c-ocmb</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-26/ddimm-0/ocmb/i2c-ocmb-master</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>OUT</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-26/ddimm-0/ocmb/i2c-ocmb-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -17535,9 +18539,35 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-26/ddimm-0/ocmb/mem_port</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-26/ddimm-0/ocmb/i2c-ts2</id>
 	<property>
 	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0x34</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-26/ddimm-0/ocmb/mem_port0</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-26/ddimm-0/ocmb/mem_port1</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -17556,7 +18586,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0x90</value>
+	<value>0xCE</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -17604,7 +18634,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0xC0</value>
+	<value>0xB4</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -17645,7 +18675,7 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-26/ddimm-0/spd/i2c-slave</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-26/ddimm-0/spdA/i2c-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -17660,6 +18690,21 @@
 	</property>
 </globalSetting>
 <globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-26/ddimm-0/spdB/i2c-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0xA2</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value>24c32</value>
+	</property>
+</globalSetting>
+<globalSetting>
 	<id>/sys-0/node-0/nisqually-0/ddimm-connector-27</id>
 	<property>
 	<id>CONNECTOR_TYPE</id>
@@ -17667,9 +18712,13 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-27/ddimm-0/ddr4</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-27/ddimm-0/ddr5</id>
 	<property>
 	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -17696,7 +18745,14 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-27/ddimm-0/ocmb/i2c-ocmb</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-27/ddimm-0/ocmb/i2c-ocmb-master</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>OUT</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-27/ddimm-0/ocmb/i2c-ocmb-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -17741,9 +18797,35 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-27/ddimm-0/ocmb/mem_port</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-27/ddimm-0/ocmb/i2c-ts2</id>
 	<property>
 	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0x34</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-27/ddimm-0/ocmb/mem_port0</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-27/ddimm-0/ocmb/mem_port1</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -17762,7 +18844,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0x90</value>
+	<value>0xCE</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -17810,7 +18892,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0xC0</value>
+	<value>0xB4</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -17851,7 +18933,7 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-27/ddimm-0/spd/i2c-slave</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-27/ddimm-0/spdA/i2c-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -17866,6 +18948,21 @@
 	</property>
 </globalSetting>
 <globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-27/ddimm-0/spdB/i2c-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0xA2</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value>24c32</value>
+	</property>
+</globalSetting>
+<globalSetting>
 	<id>/sys-0/node-0/nisqually-0/ddimm-connector-28</id>
 	<property>
 	<id>CONNECTOR_TYPE</id>
@@ -17873,9 +18970,13 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-28/ddimm-0/ddr4</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-28/ddimm-0/ddr5</id>
 	<property>
 	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -17902,7 +19003,14 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-28/ddimm-0/ocmb/i2c-ocmb</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-28/ddimm-0/ocmb/i2c-ocmb-master</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>OUT</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-28/ddimm-0/ocmb/i2c-ocmb-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -17947,9 +19055,35 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-28/ddimm-0/ocmb/mem_port</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-28/ddimm-0/ocmb/i2c-ts2</id>
 	<property>
 	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0x34</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-28/ddimm-0/ocmb/mem_port0</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-28/ddimm-0/ocmb/mem_port1</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -17968,7 +19102,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0x90</value>
+	<value>0xCE</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -18016,7 +19150,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0xC0</value>
+	<value>0xB4</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -18057,7 +19191,7 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-28/ddimm-0/spd/i2c-slave</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-28/ddimm-0/spdA/i2c-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -18065,6 +19199,21 @@
 	<property>
 	<id>I2C_ADDRESS</id>
 	<value>0xA0</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value>24c32</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-28/ddimm-0/spdB/i2c-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0xA2</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -18094,9 +19243,13 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-29/ddimm-0/ddr4</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-29/ddimm-0/ddr5</id>
 	<property>
 	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -18123,7 +19276,14 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-29/ddimm-0/ocmb/i2c-ocmb</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-29/ddimm-0/ocmb/i2c-ocmb-master</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>OUT</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-29/ddimm-0/ocmb/i2c-ocmb-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -18168,9 +19328,35 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-29/ddimm-0/ocmb/mem_port</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-29/ddimm-0/ocmb/i2c-ts2</id>
 	<property>
 	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0x34</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-29/ddimm-0/ocmb/mem_port0</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-29/ddimm-0/ocmb/mem_port1</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -18189,7 +19375,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0x90</value>
+	<value>0xCE</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -18248,7 +19434,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0xC0</value>
+	<value>0xB4</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -18289,7 +19475,7 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-29/ddimm-0/spd/i2c-slave</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-29/ddimm-0/spdA/i2c-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -18304,6 +19490,21 @@
 	</property>
 </globalSetting>
 <globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-29/ddimm-0/spdB/i2c-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0xA2</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value>24c32</value>
+	</property>
+</globalSetting>
+<globalSetting>
 	<id>/sys-0/node-0/nisqually-0/ddimm-connector-3</id>
 	<property>
 	<id>CONNECTOR_TYPE</id>
@@ -18311,9 +19512,13 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-3/ddimm-0/ddr4</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-3/ddimm-0/ddr5</id>
 	<property>
 	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -18340,7 +19545,14 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-3/ddimm-0/ocmb/i2c-ocmb</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-3/ddimm-0/ocmb/i2c-ocmb-master</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>OUT</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-3/ddimm-0/ocmb/i2c-ocmb-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -18385,9 +19597,35 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-3/ddimm-0/ocmb/mem_port</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-3/ddimm-0/ocmb/i2c-ts2</id>
 	<property>
 	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0x34</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-3/ddimm-0/ocmb/mem_port0</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-3/ddimm-0/ocmb/mem_port1</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -18406,7 +19644,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0x90</value>
+	<value>0xCE</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -18454,7 +19692,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0xC0</value>
+	<value>0xB4</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -18495,7 +19733,7 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-3/ddimm-0/spd/i2c-slave</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-3/ddimm-0/spdA/i2c-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -18510,6 +19748,21 @@
 	</property>
 </globalSetting>
 <globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-3/ddimm-0/spdB/i2c-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0xA2</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value>24c32</value>
+	</property>
+</globalSetting>
+<globalSetting>
 	<id>/sys-0/node-0/nisqually-0/ddimm-connector-30</id>
 	<property>
 	<id>CONNECTOR_TYPE</id>
@@ -18517,9 +19770,13 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-30/ddimm-0/ddr4</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-30/ddimm-0/ddr5</id>
 	<property>
 	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -18546,7 +19803,14 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-30/ddimm-0/ocmb/i2c-ocmb</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-30/ddimm-0/ocmb/i2c-ocmb-master</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>OUT</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-30/ddimm-0/ocmb/i2c-ocmb-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -18591,9 +19855,35 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-30/ddimm-0/ocmb/mem_port</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-30/ddimm-0/ocmb/i2c-ts2</id>
 	<property>
 	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0x34</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-30/ddimm-0/ocmb/mem_port0</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-30/ddimm-0/ocmb/mem_port1</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -18612,7 +19902,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0x90</value>
+	<value>0xCE</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -18660,7 +19950,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0xC0</value>
+	<value>0xB4</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -18701,7 +19991,7 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-30/ddimm-0/spd/i2c-slave</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-30/ddimm-0/spdA/i2c-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -18709,6 +19999,21 @@
 	<property>
 	<id>I2C_ADDRESS</id>
 	<value>0xA0</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value>24c32</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-30/ddimm-0/spdB/i2c-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0xA2</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -18736,11 +20041,19 @@
 	<id>IPMI_INSTANCE</id>
 	<value></value>
 	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
+	<value></value>
+	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-31/ddimm-0/ddr4</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-31/ddimm-0/ddr5</id>
 	<property>
 	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -18767,7 +20080,14 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-31/ddimm-0/ocmb/i2c-ocmb</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-31/ddimm-0/ocmb/i2c-ocmb-master</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>OUT</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-31/ddimm-0/ocmb/i2c-ocmb-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -18812,9 +20132,35 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-31/ddimm-0/ocmb/mem_port</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-31/ddimm-0/ocmb/i2c-ts2</id>
 	<property>
 	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0x34</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-31/ddimm-0/ocmb/mem_port0</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-31/ddimm-0/ocmb/mem_port1</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -18833,7 +20179,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0x90</value>
+	<value>0xCE</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -18881,7 +20227,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0xC0</value>
+	<value>0xB4</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -18922,7 +20268,7 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-31/ddimm-0/spd/i2c-slave</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-31/ddimm-0/spdA/i2c-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -18930,6 +20276,21 @@
 	<property>
 	<id>I2C_ADDRESS</id>
 	<value>0xA0</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value>24c32</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-31/ddimm-0/spdB/i2c-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0xA2</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -18955,9 +20316,13 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-4/ddimm-0/ddr4</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-4/ddimm-0/ddr5</id>
 	<property>
 	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -18984,7 +20349,14 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-4/ddimm-0/ocmb/i2c-ocmb</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-4/ddimm-0/ocmb/i2c-ocmb-master</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>OUT</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-4/ddimm-0/ocmb/i2c-ocmb-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -19029,9 +20401,35 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-4/ddimm-0/ocmb/mem_port</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-4/ddimm-0/ocmb/i2c-ts2</id>
 	<property>
 	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0x34</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-4/ddimm-0/ocmb/mem_port0</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-4/ddimm-0/ocmb/mem_port1</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -19050,7 +20448,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0x90</value>
+	<value>0xCE</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -19098,7 +20496,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0xC0</value>
+	<value>0xB4</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -19139,7 +20537,7 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-4/ddimm-0/spd/i2c-slave</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-4/ddimm-0/spdA/i2c-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -19147,6 +20545,21 @@
 	<property>
 	<id>I2C_ADDRESS</id>
 	<value>0xA0</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value>24c32</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-4/ddimm-0/spdB/i2c-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0xA2</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -19174,11 +20587,19 @@
 	<id>IPMI_INSTANCE</id>
 	<value></value>
 	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
+	<value></value>
+	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-5/ddimm-0/ddr4</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-5/ddimm-0/ddr5</id>
 	<property>
 	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -19205,7 +20626,14 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-5/ddimm-0/ocmb/i2c-ocmb</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-5/ddimm-0/ocmb/i2c-ocmb-master</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>OUT</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-5/ddimm-0/ocmb/i2c-ocmb-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -19250,9 +20678,35 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-5/ddimm-0/ocmb/mem_port</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-5/ddimm-0/ocmb/i2c-ts2</id>
 	<property>
 	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0x34</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-5/ddimm-0/ocmb/mem_port0</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-5/ddimm-0/ocmb/mem_port1</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -19271,7 +20725,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0x90</value>
+	<value>0xCE</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -19330,7 +20784,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0xC0</value>
+	<value>0xB4</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -19371,7 +20825,7 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-5/ddimm-0/spd/i2c-slave</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-5/ddimm-0/spdA/i2c-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -19379,6 +20833,21 @@
 	<property>
 	<id>I2C_ADDRESS</id>
 	<value>0xA0</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value>24c32</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-5/ddimm-0/spdB/i2c-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0xA2</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -19404,9 +20873,13 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-6/ddimm-0/ddr4</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-6/ddimm-0/ddr5</id>
 	<property>
 	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -19431,9 +20904,20 @@
 	<id>MSS_MRW_OCMB_RESET_GROUP</id>
 	<value>1</value>
 	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
+	<value></value>
+	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-6/ddimm-0/ocmb/i2c-ocmb</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-6/ddimm-0/ocmb/i2c-ocmb-master</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>OUT</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-6/ddimm-0/ocmb/i2c-ocmb-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -19478,9 +20962,35 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-6/ddimm-0/ocmb/mem_port</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-6/ddimm-0/ocmb/i2c-ts2</id>
 	<property>
 	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0x34</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-6/ddimm-0/ocmb/mem_port0</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-6/ddimm-0/ocmb/mem_port1</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -19499,7 +21009,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0x90</value>
+	<value>0xCE</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -19547,7 +21057,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0xC0</value>
+	<value>0xB4</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -19588,7 +21098,7 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-6/ddimm-0/spd/i2c-slave</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-6/ddimm-0/spdA/i2c-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -19596,6 +21106,21 @@
 	<property>
 	<id>I2C_ADDRESS</id>
 	<value>0xA0</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value>24c32</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-6/ddimm-0/spdB/i2c-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0xA2</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -19625,9 +21150,13 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-7/ddimm-0/ddr4</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-7/ddimm-0/ddr5</id>
 	<property>
 	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -19654,7 +21183,14 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-7/ddimm-0/ocmb/i2c-ocmb</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-7/ddimm-0/ocmb/i2c-ocmb-master</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>OUT</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-7/ddimm-0/ocmb/i2c-ocmb-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -19699,9 +21235,35 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-7/ddimm-0/ocmb/mem_port</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-7/ddimm-0/ocmb/i2c-ts2</id>
 	<property>
 	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0x34</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-7/ddimm-0/ocmb/mem_port0</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-7/ddimm-0/ocmb/mem_port1</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -19720,7 +21282,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0x90</value>
+	<value>0xCE</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -19768,7 +21330,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0xC0</value>
+	<value>0xB4</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -19809,7 +21371,7 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-7/ddimm-0/spd/i2c-slave</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-7/ddimm-0/spdA/i2c-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -19817,6 +21379,21 @@
 	<property>
 	<id>I2C_ADDRESS</id>
 	<value>0xA0</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value>24c32</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-7/ddimm-0/spdB/i2c-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0xA2</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -19846,9 +21423,13 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-8/ddimm-0/ddr4</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-8/ddimm-0/ddr5</id>
 	<property>
 	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -19875,7 +21456,14 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-8/ddimm-0/ocmb/i2c-ocmb</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-8/ddimm-0/ocmb/i2c-ocmb-master</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>OUT</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-8/ddimm-0/ocmb/i2c-ocmb-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -19920,9 +21508,39 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-8/ddimm-0/ocmb/mem_port</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-8/ddimm-0/ocmb/i2c-ts2</id>
 	<property>
 	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0x34</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-8/ddimm-0/ocmb/mem_port0</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-8/ddimm-0/ocmb/mem_port1</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -19941,7 +21559,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0x90</value>
+	<value>0xCE</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -19989,7 +21607,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0xC0</value>
+	<value>0xB4</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -20030,7 +21648,7 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-8/ddimm-0/spd/i2c-slave</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-8/ddimm-0/spdA/i2c-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -20045,6 +21663,21 @@
 	</property>
 </globalSetting>
 <globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-8/ddimm-0/spdB/i2c-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0xA2</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value>24c32</value>
+	</property>
+</globalSetting>
+<globalSetting>
 	<id>/sys-0/node-0/nisqually-0/ddimm-connector-9</id>
 	<property>
 	<id>CONNECTOR_TYPE</id>
@@ -20052,9 +21685,32 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-9/ddimm-0/ddr4</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-9/ddimm-0</id>
+	<property>
+	<id>FRU_ID</id>
+	<value></value>
+	</property>
+	<property>
+	<id>FRU_NAME</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-9/ddimm-0/ddr5</id>
 	<property>
 	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -20081,7 +21737,14 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-9/ddimm-0/ocmb/i2c-ocmb</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-9/ddimm-0/ocmb/i2c-ocmb-master</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>OUT</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-9/ddimm-0/ocmb/i2c-ocmb-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -20126,9 +21789,35 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-9/ddimm-0/ocmb/mem_port</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-9/ddimm-0/ocmb/i2c-ts2</id>
 	<property>
 	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0x34</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-9/ddimm-0/ocmb/mem_port0</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-9/ddimm-0/ocmb/mem_port1</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>RESOURCE_IS_CRITICAL</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -20147,7 +21836,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0x90</value>
+	<value>0xCE</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -20195,7 +21884,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0xC0</value>
+	<value>0xB4</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -20236,7 +21925,7 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/nisqually-0/ddimm-connector-9/ddimm-0/spd/i2c-slave</id>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-9/ddimm-0/spdA/i2c-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value>IN</value>
@@ -20244,6 +21933,21 @@
 	<property>
 	<id>I2C_ADDRESS</id>
 	<value>0xA0</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value>24c32</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/nisqually-0/ddimm-connector-9/ddimm-0/spdB/i2c-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value>IN</value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0xA2</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -44110,416 +45814,832 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>ddimm-connector-0/ddimm-0/ocmb/mem_port => ddimm-connector-0/ddimm-0/ddr4</bus_id>
-		<bus_type>DDR4</bus_type>
+		<bus_id>ddimm-connector-0/ddimm-0/ocmb/mem_port0 => ddimm-connector-0/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
 		<cable>no</cable>
 		<source_path>ddimm-connector-0/ddimm-0/ocmb/</source_path>
-		<source_target>mem_port</source_target>
+		<source_target>mem_port0</source_target>
 		<dest_path>ddimm-connector-0/ddimm-0/</dest_path>
-		<dest_target>ddr4</dest_target>
+		<dest_target>ddr5</dest_target>
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>ddimm-connector-1/ddimm-0/ocmb/mem_port => ddimm-connector-1/ddimm-0/ddr4</bus_id>
-		<bus_type>DDR4</bus_type>
+		<bus_id>ddimm-connector-1/ddimm-0/ocmb/mem_port0 => ddimm-connector-1/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
 		<cable>no</cable>
 		<source_path>ddimm-connector-1/ddimm-0/ocmb/</source_path>
-		<source_target>mem_port</source_target>
+		<source_target>mem_port0</source_target>
 		<dest_path>ddimm-connector-1/ddimm-0/</dest_path>
-		<dest_target>ddr4</dest_target>
+		<dest_target>ddr5</dest_target>
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>ddimm-connector-2/ddimm-0/ocmb/mem_port => ddimm-connector-2/ddimm-0/ddr4</bus_id>
-		<bus_type>DDR4</bus_type>
+		<bus_id>ddimm-connector-2/ddimm-0/ocmb/mem_port0 => ddimm-connector-2/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
 		<cable>no</cable>
 		<source_path>ddimm-connector-2/ddimm-0/ocmb/</source_path>
-		<source_target>mem_port</source_target>
+		<source_target>mem_port0</source_target>
 		<dest_path>ddimm-connector-2/ddimm-0/</dest_path>
-		<dest_target>ddr4</dest_target>
+		<dest_target>ddr5</dest_target>
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>ddimm-connector-3/ddimm-0/ocmb/mem_port => ddimm-connector-3/ddimm-0/ddr4</bus_id>
-		<bus_type>DDR4</bus_type>
+		<bus_id>ddimm-connector-3/ddimm-0/ocmb/mem_port0 => ddimm-connector-3/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
 		<cable>no</cable>
 		<source_path>ddimm-connector-3/ddimm-0/ocmb/</source_path>
-		<source_target>mem_port</source_target>
+		<source_target>mem_port0</source_target>
 		<dest_path>ddimm-connector-3/ddimm-0/</dest_path>
-		<dest_target>ddr4</dest_target>
+		<dest_target>ddr5</dest_target>
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>ddimm-connector-4/ddimm-0/ocmb/mem_port => ddimm-connector-4/ddimm-0/ddr4</bus_id>
-		<bus_type>DDR4</bus_type>
+		<bus_id>ddimm-connector-4/ddimm-0/ocmb/mem_port0 => ddimm-connector-4/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
 		<cable>no</cable>
 		<source_path>ddimm-connector-4/ddimm-0/ocmb/</source_path>
-		<source_target>mem_port</source_target>
+		<source_target>mem_port0</source_target>
 		<dest_path>ddimm-connector-4/ddimm-0/</dest_path>
-		<dest_target>ddr4</dest_target>
+		<dest_target>ddr5</dest_target>
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>ddimm-connector-5/ddimm-0/ocmb/mem_port => ddimm-connector-5/ddimm-0/ddr4</bus_id>
-		<bus_type>DDR4</bus_type>
+		<bus_id>ddimm-connector-5/ddimm-0/ocmb/mem_port0 => ddimm-connector-5/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
 		<cable>no</cable>
 		<source_path>ddimm-connector-5/ddimm-0/ocmb/</source_path>
-		<source_target>mem_port</source_target>
+		<source_target>mem_port0</source_target>
 		<dest_path>ddimm-connector-5/ddimm-0/</dest_path>
-		<dest_target>ddr4</dest_target>
+		<dest_target>ddr5</dest_target>
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>ddimm-connector-6/ddimm-0/ocmb/mem_port => ddimm-connector-6/ddimm-0/ddr4</bus_id>
-		<bus_type>DDR4</bus_type>
+		<bus_id>ddimm-connector-6/ddimm-0/ocmb/mem_port0 => ddimm-connector-6/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
 		<cable>no</cable>
 		<source_path>ddimm-connector-6/ddimm-0/ocmb/</source_path>
-		<source_target>mem_port</source_target>
+		<source_target>mem_port0</source_target>
 		<dest_path>ddimm-connector-6/ddimm-0/</dest_path>
-		<dest_target>ddr4</dest_target>
+		<dest_target>ddr5</dest_target>
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>ddimm-connector-7/ddimm-0/ocmb/mem_port => ddimm-connector-7/ddimm-0/ddr4</bus_id>
-		<bus_type>DDR4</bus_type>
+		<bus_id>ddimm-connector-7/ddimm-0/ocmb/mem_port0 => ddimm-connector-7/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
 		<cable>no</cable>
 		<source_path>ddimm-connector-7/ddimm-0/ocmb/</source_path>
-		<source_target>mem_port</source_target>
+		<source_target>mem_port0</source_target>
 		<dest_path>ddimm-connector-7/ddimm-0/</dest_path>
-		<dest_target>ddr4</dest_target>
+		<dest_target>ddr5</dest_target>
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>ddimm-connector-8/ddimm-0/ocmb/mem_port => ddimm-connector-8/ddimm-0/ddr4</bus_id>
-		<bus_type>DDR4</bus_type>
+		<bus_id>ddimm-connector-8/ddimm-0/ocmb/mem_port0 => ddimm-connector-8/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
 		<cable>no</cable>
 		<source_path>ddimm-connector-8/ddimm-0/ocmb/</source_path>
-		<source_target>mem_port</source_target>
+		<source_target>mem_port0</source_target>
 		<dest_path>ddimm-connector-8/ddimm-0/</dest_path>
-		<dest_target>ddr4</dest_target>
+		<dest_target>ddr5</dest_target>
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>ddimm-connector-9/ddimm-0/ocmb/mem_port => ddimm-connector-9/ddimm-0/ddr4</bus_id>
-		<bus_type>DDR4</bus_type>
+		<bus_id>ddimm-connector-9/ddimm-0/ocmb/mem_port0 => ddimm-connector-9/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
 		<cable>no</cable>
 		<source_path>ddimm-connector-9/ddimm-0/ocmb/</source_path>
-		<source_target>mem_port</source_target>
+		<source_target>mem_port0</source_target>
 		<dest_path>ddimm-connector-9/ddimm-0/</dest_path>
-		<dest_target>ddr4</dest_target>
+		<dest_target>ddr5</dest_target>
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>ddimm-connector-10/ddimm-0/ocmb/mem_port => ddimm-connector-10/ddimm-0/ddr4</bus_id>
-		<bus_type>DDR4</bus_type>
+		<bus_id>ddimm-connector-10/ddimm-0/ocmb/mem_port0 => ddimm-connector-10/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
 		<cable>no</cable>
 		<source_path>ddimm-connector-10/ddimm-0/ocmb/</source_path>
-		<source_target>mem_port</source_target>
+		<source_target>mem_port0</source_target>
 		<dest_path>ddimm-connector-10/ddimm-0/</dest_path>
-		<dest_target>ddr4</dest_target>
+		<dest_target>ddr5</dest_target>
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>ddimm-connector-11/ddimm-0/ocmb/mem_port => ddimm-connector-11/ddimm-0/ddr4</bus_id>
-		<bus_type>DDR4</bus_type>
+		<bus_id>ddimm-connector-11/ddimm-0/ocmb/mem_port0 => ddimm-connector-11/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
 		<cable>no</cable>
 		<source_path>ddimm-connector-11/ddimm-0/ocmb/</source_path>
-		<source_target>mem_port</source_target>
+		<source_target>mem_port0</source_target>
 		<dest_path>ddimm-connector-11/ddimm-0/</dest_path>
-		<dest_target>ddr4</dest_target>
+		<dest_target>ddr5</dest_target>
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>ddimm-connector-12/ddimm-0/ocmb/mem_port => ddimm-connector-12/ddimm-0/ddr4</bus_id>
-		<bus_type>DDR4</bus_type>
+		<bus_id>ddimm-connector-12/ddimm-0/ocmb/mem_port0 => ddimm-connector-12/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
 		<cable>no</cable>
 		<source_path>ddimm-connector-12/ddimm-0/ocmb/</source_path>
-		<source_target>mem_port</source_target>
+		<source_target>mem_port0</source_target>
 		<dest_path>ddimm-connector-12/ddimm-0/</dest_path>
-		<dest_target>ddr4</dest_target>
+		<dest_target>ddr5</dest_target>
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>ddimm-connector-13/ddimm-0/ocmb/mem_port => ddimm-connector-13/ddimm-0/ddr4</bus_id>
-		<bus_type>DDR4</bus_type>
+		<bus_id>ddimm-connector-13/ddimm-0/ocmb/mem_port0 => ddimm-connector-13/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
 		<cable>no</cable>
 		<source_path>ddimm-connector-13/ddimm-0/ocmb/</source_path>
-		<source_target>mem_port</source_target>
+		<source_target>mem_port0</source_target>
 		<dest_path>ddimm-connector-13/ddimm-0/</dest_path>
-		<dest_target>ddr4</dest_target>
+		<dest_target>ddr5</dest_target>
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>ddimm-connector-14/ddimm-0/ocmb/mem_port => ddimm-connector-14/ddimm-0/ddr4</bus_id>
-		<bus_type>DDR4</bus_type>
+		<bus_id>ddimm-connector-14/ddimm-0/ocmb/mem_port0 => ddimm-connector-14/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
 		<cable>no</cable>
 		<source_path>ddimm-connector-14/ddimm-0/ocmb/</source_path>
-		<source_target>mem_port</source_target>
+		<source_target>mem_port0</source_target>
 		<dest_path>ddimm-connector-14/ddimm-0/</dest_path>
-		<dest_target>ddr4</dest_target>
+		<dest_target>ddr5</dest_target>
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>ddimm-connector-15/ddimm-0/ocmb/mem_port => ddimm-connector-15/ddimm-0/ddr4</bus_id>
-		<bus_type>DDR4</bus_type>
+		<bus_id>ddimm-connector-15/ddimm-0/ocmb/mem_port0 => ddimm-connector-15/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
 		<cable>no</cable>
 		<source_path>ddimm-connector-15/ddimm-0/ocmb/</source_path>
-		<source_target>mem_port</source_target>
+		<source_target>mem_port0</source_target>
 		<dest_path>ddimm-connector-15/ddimm-0/</dest_path>
-		<dest_target>ddr4</dest_target>
+		<dest_target>ddr5</dest_target>
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>ddimm-connector-16/ddimm-0/ocmb/mem_port => ddimm-connector-16/ddimm-0/ddr4</bus_id>
-		<bus_type>DDR4</bus_type>
+		<bus_id>ddimm-connector-16/ddimm-0/ocmb/mem_port0 => ddimm-connector-16/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
 		<cable>no</cable>
 		<source_path>ddimm-connector-16/ddimm-0/ocmb/</source_path>
-		<source_target>mem_port</source_target>
+		<source_target>mem_port0</source_target>
 		<dest_path>ddimm-connector-16/ddimm-0/</dest_path>
-		<dest_target>ddr4</dest_target>
+		<dest_target>ddr5</dest_target>
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>ddimm-connector-17/ddimm-0/ocmb/mem_port => ddimm-connector-17/ddimm-0/ddr4</bus_id>
-		<bus_type>DDR4</bus_type>
+		<bus_id>ddimm-connector-17/ddimm-0/ocmb/mem_port0 => ddimm-connector-17/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
 		<cable>no</cable>
 		<source_path>ddimm-connector-17/ddimm-0/ocmb/</source_path>
-		<source_target>mem_port</source_target>
+		<source_target>mem_port0</source_target>
 		<dest_path>ddimm-connector-17/ddimm-0/</dest_path>
-		<dest_target>ddr4</dest_target>
+		<dest_target>ddr5</dest_target>
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>ddimm-connector-18/ddimm-0/ocmb/mem_port => ddimm-connector-18/ddimm-0/ddr4</bus_id>
-		<bus_type>DDR4</bus_type>
+		<bus_id>ddimm-connector-18/ddimm-0/ocmb/mem_port0 => ddimm-connector-18/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
 		<cable>no</cable>
 		<source_path>ddimm-connector-18/ddimm-0/ocmb/</source_path>
-		<source_target>mem_port</source_target>
+		<source_target>mem_port0</source_target>
 		<dest_path>ddimm-connector-18/ddimm-0/</dest_path>
-		<dest_target>ddr4</dest_target>
+		<dest_target>ddr5</dest_target>
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>ddimm-connector-19/ddimm-0/ocmb/mem_port => ddimm-connector-19/ddimm-0/ddr4</bus_id>
-		<bus_type>DDR4</bus_type>
+		<bus_id>ddimm-connector-19/ddimm-0/ocmb/mem_port0 => ddimm-connector-19/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
 		<cable>no</cable>
 		<source_path>ddimm-connector-19/ddimm-0/ocmb/</source_path>
-		<source_target>mem_port</source_target>
+		<source_target>mem_port0</source_target>
 		<dest_path>ddimm-connector-19/ddimm-0/</dest_path>
-		<dest_target>ddr4</dest_target>
+		<dest_target>ddr5</dest_target>
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>ddimm-connector-20/ddimm-0/ocmb/mem_port => ddimm-connector-20/ddimm-0/ddr4</bus_id>
-		<bus_type>DDR4</bus_type>
+		<bus_id>ddimm-connector-20/ddimm-0/ocmb/mem_port0 => ddimm-connector-20/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
 		<cable>no</cable>
 		<source_path>ddimm-connector-20/ddimm-0/ocmb/</source_path>
-		<source_target>mem_port</source_target>
+		<source_target>mem_port0</source_target>
 		<dest_path>ddimm-connector-20/ddimm-0/</dest_path>
-		<dest_target>ddr4</dest_target>
+		<dest_target>ddr5</dest_target>
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>ddimm-connector-21/ddimm-0/ocmb/mem_port => ddimm-connector-21/ddimm-0/ddr4</bus_id>
-		<bus_type>DDR4</bus_type>
+		<bus_id>ddimm-connector-21/ddimm-0/ocmb/mem_port0 => ddimm-connector-21/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
 		<cable>no</cable>
 		<source_path>ddimm-connector-21/ddimm-0/ocmb/</source_path>
-		<source_target>mem_port</source_target>
+		<source_target>mem_port0</source_target>
 		<dest_path>ddimm-connector-21/ddimm-0/</dest_path>
-		<dest_target>ddr4</dest_target>
+		<dest_target>ddr5</dest_target>
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>ddimm-connector-22/ddimm-0/ocmb/mem_port => ddimm-connector-22/ddimm-0/ddr4</bus_id>
-		<bus_type>DDR4</bus_type>
+		<bus_id>ddimm-connector-22/ddimm-0/ocmb/mem_port0 => ddimm-connector-22/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
 		<cable>no</cable>
 		<source_path>ddimm-connector-22/ddimm-0/ocmb/</source_path>
-		<source_target>mem_port</source_target>
+		<source_target>mem_port0</source_target>
 		<dest_path>ddimm-connector-22/ddimm-0/</dest_path>
-		<dest_target>ddr4</dest_target>
+		<dest_target>ddr5</dest_target>
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>ddimm-connector-23/ddimm-0/ocmb/mem_port => ddimm-connector-23/ddimm-0/ddr4</bus_id>
-		<bus_type>DDR4</bus_type>
+		<bus_id>ddimm-connector-23/ddimm-0/ocmb/mem_port0 => ddimm-connector-23/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
 		<cable>no</cable>
 		<source_path>ddimm-connector-23/ddimm-0/ocmb/</source_path>
-		<source_target>mem_port</source_target>
+		<source_target>mem_port0</source_target>
 		<dest_path>ddimm-connector-23/ddimm-0/</dest_path>
-		<dest_target>ddr4</dest_target>
+		<dest_target>ddr5</dest_target>
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>ddimm-connector-24/ddimm-0/ocmb/mem_port => ddimm-connector-24/ddimm-0/ddr4</bus_id>
-		<bus_type>DDR4</bus_type>
+		<bus_id>ddimm-connector-24/ddimm-0/ocmb/mem_port0 => ddimm-connector-24/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
 		<cable>no</cable>
 		<source_path>ddimm-connector-24/ddimm-0/ocmb/</source_path>
-		<source_target>mem_port</source_target>
+		<source_target>mem_port0</source_target>
 		<dest_path>ddimm-connector-24/ddimm-0/</dest_path>
-		<dest_target>ddr4</dest_target>
+		<dest_target>ddr5</dest_target>
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>ddimm-connector-25/ddimm-0/ocmb/mem_port => ddimm-connector-25/ddimm-0/ddr4</bus_id>
-		<bus_type>DDR4</bus_type>
+		<bus_id>ddimm-connector-25/ddimm-0/ocmb/mem_port0 => ddimm-connector-25/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
 		<cable>no</cable>
 		<source_path>ddimm-connector-25/ddimm-0/ocmb/</source_path>
-		<source_target>mem_port</source_target>
+		<source_target>mem_port0</source_target>
 		<dest_path>ddimm-connector-25/ddimm-0/</dest_path>
-		<dest_target>ddr4</dest_target>
+		<dest_target>ddr5</dest_target>
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>ddimm-connector-26/ddimm-0/ocmb/mem_port => ddimm-connector-26/ddimm-0/ddr4</bus_id>
-		<bus_type>DDR4</bus_type>
+		<bus_id>ddimm-connector-26/ddimm-0/ocmb/mem_port0 => ddimm-connector-26/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
 		<cable>no</cable>
 		<source_path>ddimm-connector-26/ddimm-0/ocmb/</source_path>
-		<source_target>mem_port</source_target>
+		<source_target>mem_port0</source_target>
 		<dest_path>ddimm-connector-26/ddimm-0/</dest_path>
-		<dest_target>ddr4</dest_target>
+		<dest_target>ddr5</dest_target>
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>ddimm-connector-27/ddimm-0/ocmb/mem_port => ddimm-connector-27/ddimm-0/ddr4</bus_id>
-		<bus_type>DDR4</bus_type>
+		<bus_id>ddimm-connector-27/ddimm-0/ocmb/mem_port0 => ddimm-connector-27/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
 		<cable>no</cable>
 		<source_path>ddimm-connector-27/ddimm-0/ocmb/</source_path>
-		<source_target>mem_port</source_target>
+		<source_target>mem_port0</source_target>
 		<dest_path>ddimm-connector-27/ddimm-0/</dest_path>
-		<dest_target>ddr4</dest_target>
+		<dest_target>ddr5</dest_target>
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>ddimm-connector-28/ddimm-0/ocmb/mem_port => ddimm-connector-28/ddimm-0/ddr4</bus_id>
-		<bus_type>DDR4</bus_type>
+		<bus_id>ddimm-connector-28/ddimm-0/ocmb/mem_port0 => ddimm-connector-28/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
 		<cable>no</cable>
 		<source_path>ddimm-connector-28/ddimm-0/ocmb/</source_path>
-		<source_target>mem_port</source_target>
+		<source_target>mem_port0</source_target>
 		<dest_path>ddimm-connector-28/ddimm-0/</dest_path>
-		<dest_target>ddr4</dest_target>
+		<dest_target>ddr5</dest_target>
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>ddimm-connector-29/ddimm-0/ocmb/mem_port => ddimm-connector-29/ddimm-0/ddr4</bus_id>
-		<bus_type>DDR4</bus_type>
+		<bus_id>ddimm-connector-29/ddimm-0/ocmb/mem_port0 => ddimm-connector-29/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
 		<cable>no</cable>
 		<source_path>ddimm-connector-29/ddimm-0/ocmb/</source_path>
-		<source_target>mem_port</source_target>
+		<source_target>mem_port0</source_target>
 		<dest_path>ddimm-connector-29/ddimm-0/</dest_path>
-		<dest_target>ddr4</dest_target>
+		<dest_target>ddr5</dest_target>
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>ddimm-connector-30/ddimm-0/ocmb/mem_port => ddimm-connector-30/ddimm-0/ddr4</bus_id>
-		<bus_type>DDR4</bus_type>
+		<bus_id>ddimm-connector-30/ddimm-0/ocmb/mem_port0 => ddimm-connector-30/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
 		<cable>no</cable>
 		<source_path>ddimm-connector-30/ddimm-0/ocmb/</source_path>
-		<source_target>mem_port</source_target>
+		<source_target>mem_port0</source_target>
 		<dest_path>ddimm-connector-30/ddimm-0/</dest_path>
-		<dest_target>ddr4</dest_target>
+		<dest_target>ddr5</dest_target>
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>ddimm-connector-31/ddimm-0/ocmb/mem_port => ddimm-connector-31/ddimm-0/ddr4</bus_id>
-		<bus_type>DDR4</bus_type>
+		<bus_id>ddimm-connector-31/ddimm-0/ocmb/mem_port0 => ddimm-connector-31/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
 		<cable>no</cable>
 		<source_path>ddimm-connector-31/ddimm-0/ocmb/</source_path>
-		<source_target>mem_port</source_target>
+		<source_target>mem_port0</source_target>
 		<dest_path>ddimm-connector-31/ddimm-0/</dest_path>
-		<dest_target>ddr4</dest_target>
+		<dest_target>ddr5</dest_target>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-0/ddimm-0/ocmb/mem_port1 => ddimm-connector-0/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-0/ddimm-0/ocmb/</source_path>
+		<source_target>mem_port1</source_target>
+		<dest_path>ddimm-connector-0/ddimm-0/</dest_path>
+		<dest_target>ddr5</dest_target>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-1/ddimm-0/ocmb/mem_port1 => ddimm-connector-1/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-1/ddimm-0/ocmb/</source_path>
+		<source_target>mem_port1</source_target>
+		<dest_path>ddimm-connector-1/ddimm-0/</dest_path>
+		<dest_target>ddr5</dest_target>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-2/ddimm-0/ocmb/mem_port1 => ddimm-connector-2/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-2/ddimm-0/ocmb/</source_path>
+		<source_target>mem_port1</source_target>
+		<dest_path>ddimm-connector-2/ddimm-0/</dest_path>
+		<dest_target>ddr5</dest_target>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-3/ddimm-0/ocmb/mem_port1 => ddimm-connector-3/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-3/ddimm-0/ocmb/</source_path>
+		<source_target>mem_port1</source_target>
+		<dest_path>ddimm-connector-3/ddimm-0/</dest_path>
+		<dest_target>ddr5</dest_target>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-4/ddimm-0/ocmb/mem_port1 => ddimm-connector-4/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-4/ddimm-0/ocmb/</source_path>
+		<source_target>mem_port1</source_target>
+		<dest_path>ddimm-connector-4/ddimm-0/</dest_path>
+		<dest_target>ddr5</dest_target>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-5/ddimm-0/ocmb/mem_port1 => ddimm-connector-5/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-5/ddimm-0/ocmb/</source_path>
+		<source_target>mem_port1</source_target>
+		<dest_path>ddimm-connector-5/ddimm-0/</dest_path>
+		<dest_target>ddr5</dest_target>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-6/ddimm-0/ocmb/mem_port1 => ddimm-connector-6/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-6/ddimm-0/ocmb/</source_path>
+		<source_target>mem_port1</source_target>
+		<dest_path>ddimm-connector-6/ddimm-0/</dest_path>
+		<dest_target>ddr5</dest_target>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-7/ddimm-0/ocmb/mem_port1 => ddimm-connector-7/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-7/ddimm-0/ocmb/</source_path>
+		<source_target>mem_port1</source_target>
+		<dest_path>ddimm-connector-7/ddimm-0/</dest_path>
+		<dest_target>ddr5</dest_target>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-8/ddimm-0/ocmb/mem_port1 => ddimm-connector-8/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-8/ddimm-0/ocmb/</source_path>
+		<source_target>mem_port1</source_target>
+		<dest_path>ddimm-connector-8/ddimm-0/</dest_path>
+		<dest_target>ddr5</dest_target>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-9/ddimm-0/ocmb/mem_port1 => ddimm-connector-9/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-9/ddimm-0/ocmb/</source_path>
+		<source_target>mem_port1</source_target>
+		<dest_path>ddimm-connector-9/ddimm-0/</dest_path>
+		<dest_target>ddr5</dest_target>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-10/ddimm-0/ocmb/mem_port1 => ddimm-connector-10/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-10/ddimm-0/ocmb/</source_path>
+		<source_target>mem_port1</source_target>
+		<dest_path>ddimm-connector-10/ddimm-0/</dest_path>
+		<dest_target>ddr5</dest_target>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-11/ddimm-0/ocmb/mem_port1 => ddimm-connector-11/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-11/ddimm-0/ocmb/</source_path>
+		<source_target>mem_port1</source_target>
+		<dest_path>ddimm-connector-11/ddimm-0/</dest_path>
+		<dest_target>ddr5</dest_target>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-12/ddimm-0/ocmb/mem_port1 => ddimm-connector-12/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-12/ddimm-0/ocmb/</source_path>
+		<source_target>mem_port1</source_target>
+		<dest_path>ddimm-connector-12/ddimm-0/</dest_path>
+		<dest_target>ddr5</dest_target>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-13/ddimm-0/ocmb/mem_port1 => ddimm-connector-13/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-13/ddimm-0/ocmb/</source_path>
+		<source_target>mem_port1</source_target>
+		<dest_path>ddimm-connector-13/ddimm-0/</dest_path>
+		<dest_target>ddr5</dest_target>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-14/ddimm-0/ocmb/mem_port1 => ddimm-connector-14/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-14/ddimm-0/ocmb/</source_path>
+		<source_target>mem_port1</source_target>
+		<dest_path>ddimm-connector-14/ddimm-0/</dest_path>
+		<dest_target>ddr5</dest_target>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-15/ddimm-0/ocmb/mem_port1 => ddimm-connector-15/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-15/ddimm-0/ocmb/</source_path>
+		<source_target>mem_port1</source_target>
+		<dest_path>ddimm-connector-15/ddimm-0/</dest_path>
+		<dest_target>ddr5</dest_target>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-16/ddimm-0/ocmb/mem_port1 => ddimm-connector-16/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-16/ddimm-0/ocmb/</source_path>
+		<source_target>mem_port1</source_target>
+		<dest_path>ddimm-connector-16/ddimm-0/</dest_path>
+		<dest_target>ddr5</dest_target>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-17/ddimm-0/ocmb/mem_port1 => ddimm-connector-17/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-17/ddimm-0/ocmb/</source_path>
+		<source_target>mem_port1</source_target>
+		<dest_path>ddimm-connector-17/ddimm-0/</dest_path>
+		<dest_target>ddr5</dest_target>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-18/ddimm-0/ocmb/mem_port1 => ddimm-connector-18/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-18/ddimm-0/ocmb/</source_path>
+		<source_target>mem_port1</source_target>
+		<dest_path>ddimm-connector-18/ddimm-0/</dest_path>
+		<dest_target>ddr5</dest_target>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-19/ddimm-0/ocmb/mem_port1 => ddimm-connector-19/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-19/ddimm-0/ocmb/</source_path>
+		<source_target>mem_port1</source_target>
+		<dest_path>ddimm-connector-19/ddimm-0/</dest_path>
+		<dest_target>ddr5</dest_target>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-20/ddimm-0/ocmb/mem_port1 => ddimm-connector-20/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-20/ddimm-0/ocmb/</source_path>
+		<source_target>mem_port1</source_target>
+		<dest_path>ddimm-connector-20/ddimm-0/</dest_path>
+		<dest_target>ddr5</dest_target>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-21/ddimm-0/ocmb/mem_port1 => ddimm-connector-21/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-21/ddimm-0/ocmb/</source_path>
+		<source_target>mem_port1</source_target>
+		<dest_path>ddimm-connector-21/ddimm-0/</dest_path>
+		<dest_target>ddr5</dest_target>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-22/ddimm-0/ocmb/mem_port1 => ddimm-connector-22/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-22/ddimm-0/ocmb/</source_path>
+		<source_target>mem_port1</source_target>
+		<dest_path>ddimm-connector-22/ddimm-0/</dest_path>
+		<dest_target>ddr5</dest_target>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-23/ddimm-0/ocmb/mem_port1 => ddimm-connector-23/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-23/ddimm-0/ocmb/</source_path>
+		<source_target>mem_port1</source_target>
+		<dest_path>ddimm-connector-23/ddimm-0/</dest_path>
+		<dest_target>ddr5</dest_target>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-24/ddimm-0/ocmb/mem_port1 => ddimm-connector-24/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-24/ddimm-0/ocmb/</source_path>
+		<source_target>mem_port1</source_target>
+		<dest_path>ddimm-connector-24/ddimm-0/</dest_path>
+		<dest_target>ddr5</dest_target>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-25/ddimm-0/ocmb/mem_port1 => ddimm-connector-25/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-25/ddimm-0/ocmb/</source_path>
+		<source_target>mem_port1</source_target>
+		<dest_path>ddimm-connector-25/ddimm-0/</dest_path>
+		<dest_target>ddr5</dest_target>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-26/ddimm-0/ocmb/mem_port1 => ddimm-connector-26/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-26/ddimm-0/ocmb/</source_path>
+		<source_target>mem_port1</source_target>
+		<dest_path>ddimm-connector-26/ddimm-0/</dest_path>
+		<dest_target>ddr5</dest_target>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-27/ddimm-0/ocmb/mem_port1 => ddimm-connector-27/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-27/ddimm-0/ocmb/</source_path>
+		<source_target>mem_port1</source_target>
+		<dest_path>ddimm-connector-27/ddimm-0/</dest_path>
+		<dest_target>ddr5</dest_target>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-28/ddimm-0/ocmb/mem_port1 => ddimm-connector-28/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-28/ddimm-0/ocmb/</source_path>
+		<source_target>mem_port1</source_target>
+		<dest_path>ddimm-connector-28/ddimm-0/</dest_path>
+		<dest_target>ddr5</dest_target>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-29/ddimm-0/ocmb/mem_port1 => ddimm-connector-29/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-29/ddimm-0/ocmb/</source_path>
+		<source_target>mem_port1</source_target>
+		<dest_path>ddimm-connector-29/ddimm-0/</dest_path>
+		<dest_target>ddr5</dest_target>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-30/ddimm-0/ocmb/mem_port1 => ddimm-connector-30/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-30/ddimm-0/ocmb/</source_path>
+		<source_target>mem_port1</source_target>
+		<dest_path>ddimm-connector-30/ddimm-0/</dest_path>
+		<dest_target>ddr5</dest_target>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-31/ddimm-0/ocmb/mem_port1 => ddimm-connector-31/ddimm-0/ddr5</bus_id>
+		<bus_type>DDR5</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-31/ddimm-0/ocmb/</source_path>
+		<source_target>mem_port1</source_target>
+		<dest_path>ddimm-connector-31/ddimm-0/</dest_path>
+		<dest_target>ddr5</dest_target>
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
@@ -50236,87 +52356,13 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-op3b => ddimm-connector-0/ddimm-0/ocmb/i2c-ocmb</bus_id>
+		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-op3b => ddimm-connector-0/ddimm-0/ocmb/i2c-ocmb-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-0/godel-0/power10-0/</source_path>
 		<source_target>i2c-master-op3b</source_target>
 		<dest_path>ddimm-connector-0/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ocmb</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-0/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-op3b => ddimm-connector-0/ddimm-0/ocmb/i2c-ts0</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-0/godel-0/power10-0/</source_path>
-		<source_target>i2c-master-op3b</source_target>
-		<dest_path>ddimm-connector-0/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts0</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-0/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-op3b => ddimm-connector-0/ddimm-0/ocmb/i2c-ts1</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-0/godel-0/power10-0/</source_path>
-		<source_target>i2c-master-op3b</source_target>
-		<dest_path>ddimm-connector-0/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts1</dest_target>
+		<dest_target>i2c-ocmb-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
 		<default>2</default>
@@ -50421,12 +52467,12 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-op3b => ddimm-connector-0/ddimm-0/spd/i2c-slave</bus_id>
+		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-op3b => ddimm-connector-0/ddimm-0/spdA/i2c-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-0/godel-0/power10-0/</source_path>
 		<source_target>i2c-master-op3b</source_target>
-		<dest_path>ddimm-connector-0/ddimm-0/spd/</dest_path>
+		<dest_path>ddimm-connector-0/ddimm-0/spdA/</dest_path>
 		<dest_target>i2c-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
@@ -50458,87 +52504,13 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-op3a => ddimm-connector-1/ddimm-0/ocmb/i2c-ocmb</bus_id>
+		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-op3a => ddimm-connector-1/ddimm-0/ocmb/i2c-ocmb-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-0/godel-0/power10-0/</source_path>
 		<source_target>i2c-master-op3a</source_target>
 		<dest_path>ddimm-connector-1/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ocmb</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-1/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-op3a => ddimm-connector-1/ddimm-0/ocmb/i2c-ts0</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-0/godel-0/power10-0/</source_path>
-		<source_target>i2c-master-op3a</source_target>
-		<dest_path>ddimm-connector-1/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts0</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-1/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-op3a => ddimm-connector-1/ddimm-0/ocmb/i2c-ts1</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-0/godel-0/power10-0/</source_path>
-		<source_target>i2c-master-op3a</source_target>
-		<dest_path>ddimm-connector-1/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts1</dest_target>
+		<dest_target>i2c-ocmb-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
 		<default>2</default>
@@ -50643,12 +52615,12 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-op3a => ddimm-connector-1/ddimm-0/spd/i2c-slave</bus_id>
+		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-op3a => ddimm-connector-1/ddimm-0/spdA/i2c-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-0/godel-0/power10-0/</source_path>
 		<source_target>i2c-master-op3a</source_target>
-		<dest_path>ddimm-connector-1/ddimm-0/spd/</dest_path>
+		<dest_path>ddimm-connector-1/ddimm-0/spdA/</dest_path>
 		<dest_target>i2c-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
@@ -50680,87 +52652,13 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-op4a => ddimm-connector-2/ddimm-0/ocmb/i2c-ocmb</bus_id>
+		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-op4a => ddimm-connector-2/ddimm-0/ocmb/i2c-ocmb-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-0/godel-0/power10-0/</source_path>
 		<source_target>i2c-master-op4a</source_target>
 		<dest_path>ddimm-connector-2/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ocmb</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-2/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-op4a => ddimm-connector-2/ddimm-0/ocmb/i2c-ts0</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-0/godel-0/power10-0/</source_path>
-		<source_target>i2c-master-op4a</source_target>
-		<dest_path>ddimm-connector-2/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts0</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-2/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-op4a => ddimm-connector-2/ddimm-0/ocmb/i2c-ts1</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-0/godel-0/power10-0/</source_path>
-		<source_target>i2c-master-op4a</source_target>
-		<dest_path>ddimm-connector-2/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts1</dest_target>
+		<dest_target>i2c-ocmb-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
 		<default>2</default>
@@ -50865,12 +52763,12 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-op4a => ddimm-connector-2/ddimm-0/spd/i2c-slave</bus_id>
+		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-op4a => ddimm-connector-2/ddimm-0/spdA/i2c-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-0/godel-0/power10-0/</source_path>
 		<source_target>i2c-master-op4a</source_target>
-		<dest_path>ddimm-connector-2/ddimm-0/spd/</dest_path>
+		<dest_path>ddimm-connector-2/ddimm-0/spdA/</dest_path>
 		<dest_target>i2c-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
@@ -50902,87 +52800,13 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-op4b => ddimm-connector-3/ddimm-0/ocmb/i2c-ocmb</bus_id>
+		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-op4b => ddimm-connector-3/ddimm-0/ocmb/i2c-ocmb-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-0/godel-0/power10-0/</source_path>
 		<source_target>i2c-master-op4b</source_target>
 		<dest_path>ddimm-connector-3/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ocmb</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-3/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-op4b => ddimm-connector-3/ddimm-0/ocmb/i2c-ts0</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-0/godel-0/power10-0/</source_path>
-		<source_target>i2c-master-op4b</source_target>
-		<dest_path>ddimm-connector-3/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts0</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-3/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-op4b => ddimm-connector-3/ddimm-0/ocmb/i2c-ts1</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-0/godel-0/power10-0/</source_path>
-		<source_target>i2c-master-op4b</source_target>
-		<dest_path>ddimm-connector-3/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts1</dest_target>
+		<dest_target>i2c-ocmb-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
 		<default>2</default>
@@ -51087,12 +52911,12 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-op4b => ddimm-connector-3/ddimm-0/spd/i2c-slave</bus_id>
+		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-op4b => ddimm-connector-3/ddimm-0/spdA/i2c-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-0/godel-0/power10-0/</source_path>
 		<source_target>i2c-master-op4b</source_target>
-		<dest_path>ddimm-connector-3/ddimm-0/spd/</dest_path>
+		<dest_path>ddimm-connector-3/ddimm-0/spdA/</dest_path>
 		<dest_target>i2c-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
@@ -51124,87 +52948,13 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-op5b => ddimm-connector-4/ddimm-0/ocmb/i2c-ocmb</bus_id>
+		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-op5b => ddimm-connector-4/ddimm-0/ocmb/i2c-ocmb-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-0/godel-0/power10-0/</source_path>
 		<source_target>i2c-master-op5b</source_target>
 		<dest_path>ddimm-connector-4/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ocmb</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-4/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-op5b => ddimm-connector-4/ddimm-0/ocmb/i2c-ts0</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-0/godel-0/power10-0/</source_path>
-		<source_target>i2c-master-op5b</source_target>
-		<dest_path>ddimm-connector-4/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts0</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-4/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-op5b => ddimm-connector-4/ddimm-0/ocmb/i2c-ts1</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-0/godel-0/power10-0/</source_path>
-		<source_target>i2c-master-op5b</source_target>
-		<dest_path>ddimm-connector-4/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts1</dest_target>
+		<dest_target>i2c-ocmb-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
 		<default>2</default>
@@ -51309,12 +53059,12 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-op5b => ddimm-connector-4/ddimm-0/spd/i2c-slave</bus_id>
+		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-op5b => ddimm-connector-4/ddimm-0/spdA/i2c-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-0/godel-0/power10-0/</source_path>
 		<source_target>i2c-master-op5b</source_target>
-		<dest_path>ddimm-connector-4/ddimm-0/spd/</dest_path>
+		<dest_path>ddimm-connector-4/ddimm-0/spdA/</dest_path>
 		<dest_target>i2c-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
@@ -51346,87 +53096,13 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-dimm01 => ddimm-connector-5/ddimm-0/ocmb/i2c-ocmb</bus_id>
+		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-dimm01 => ddimm-connector-5/ddimm-0/ocmb/i2c-ocmb-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-0/godel-0/power10-0/</source_path>
 		<source_target>i2c-master-dimm01</source_target>
 		<dest_path>ddimm-connector-5/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ocmb</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-5/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-dimm01 => ddimm-connector-5/ddimm-0/ocmb/i2c-ts0</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-0/godel-0/power10-0/</source_path>
-		<source_target>i2c-master-dimm01</source_target>
-		<dest_path>ddimm-connector-5/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts0</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-5/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-dimm01 => ddimm-connector-5/ddimm-0/ocmb/i2c-ts1</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-0/godel-0/power10-0/</source_path>
-		<source_target>i2c-master-dimm01</source_target>
-		<dest_path>ddimm-connector-5/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts1</dest_target>
+		<dest_target>i2c-ocmb-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
 		<default>2</default>
@@ -51531,12 +53207,12 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-dimm01 => ddimm-connector-5/ddimm-0/spd/i2c-slave</bus_id>
+		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-dimm01 => ddimm-connector-5/ddimm-0/spdA/i2c-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-0/godel-0/power10-0/</source_path>
 		<source_target>i2c-master-dimm01</source_target>
-		<dest_path>ddimm-connector-5/ddimm-0/spd/</dest_path>
+		<dest_path>ddimm-connector-5/ddimm-0/spdA/</dest_path>
 		<dest_target>i2c-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
@@ -51568,87 +53244,13 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-op5a => ddimm-connector-6/ddimm-0/ocmb/i2c-ocmb</bus_id>
+		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-op5a => ddimm-connector-6/ddimm-0/ocmb/i2c-ocmb-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-0/godel-0/power10-0/</source_path>
 		<source_target>i2c-master-op5a</source_target>
 		<dest_path>ddimm-connector-6/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ocmb</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-6/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-op5a => ddimm-connector-6/ddimm-0/ocmb/i2c-ts0</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-0/godel-0/power10-0/</source_path>
-		<source_target>i2c-master-op5a</source_target>
-		<dest_path>ddimm-connector-6/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts0</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-6/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-op5a => ddimm-connector-6/ddimm-0/ocmb/i2c-ts1</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-0/godel-0/power10-0/</source_path>
-		<source_target>i2c-master-op5a</source_target>
-		<dest_path>ddimm-connector-6/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts1</dest_target>
+		<dest_target>i2c-ocmb-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
 		<default>2</default>
@@ -51753,12 +53355,12 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-op5a => ddimm-connector-6/ddimm-0/spd/i2c-slave</bus_id>
+		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-op5a => ddimm-connector-6/ddimm-0/spdA/i2c-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-0/godel-0/power10-0/</source_path>
 		<source_target>i2c-master-op5a</source_target>
-		<dest_path>ddimm-connector-6/ddimm-0/spd/</dest_path>
+		<dest_path>ddimm-connector-6/ddimm-0/spdA/</dest_path>
 		<dest_target>i2c-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
@@ -51790,87 +53392,13 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-dimm23 => ddimm-connector-7/ddimm-0/ocmb/i2c-ocmb</bus_id>
+		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-dimm23 => ddimm-connector-7/ddimm-0/ocmb/i2c-ocmb-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-0/godel-0/power10-0/</source_path>
 		<source_target>i2c-master-dimm23</source_target>
 		<dest_path>ddimm-connector-7/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ocmb</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-7/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-dimm23 => ddimm-connector-7/ddimm-0/ocmb/i2c-ts0</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-0/godel-0/power10-0/</source_path>
-		<source_target>i2c-master-dimm23</source_target>
-		<dest_path>ddimm-connector-7/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts0</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-7/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-dimm23 => ddimm-connector-7/ddimm-0/ocmb/i2c-ts1</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-0/godel-0/power10-0/</source_path>
-		<source_target>i2c-master-dimm23</source_target>
-		<dest_path>ddimm-connector-7/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts1</dest_target>
+		<dest_target>i2c-ocmb-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
 		<default>2</default>
@@ -51975,12 +53503,12 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-dimm23 => ddimm-connector-7/ddimm-0/spd/i2c-slave</bus_id>
+		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-dimm23 => ddimm-connector-7/ddimm-0/spdA/i2c-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-0/godel-0/power10-0/</source_path>
 		<source_target>i2c-master-dimm23</source_target>
-		<dest_path>ddimm-connector-7/ddimm-0/spd/</dest_path>
+		<dest_path>ddimm-connector-7/ddimm-0/spdA/</dest_path>
 		<dest_target>i2c-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
@@ -52012,87 +53540,13 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-dimm45 => ddimm-connector-8/ddimm-0/ocmb/i2c-ocmb</bus_id>
+		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-dimm45 => ddimm-connector-8/ddimm-0/ocmb/i2c-ocmb-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-0/godel-0/power10-1/</source_path>
 		<source_target>i2c-master-dimm45</source_target>
 		<dest_path>ddimm-connector-8/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ocmb</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-8/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-dimm45 => ddimm-connector-8/ddimm-0/ocmb/i2c-ts0</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-0/godel-0/power10-1/</source_path>
-		<source_target>i2c-master-dimm45</source_target>
-		<dest_path>ddimm-connector-8/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts0</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-8/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-dimm45 => ddimm-connector-8/ddimm-0/ocmb/i2c-ts1</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-0/godel-0/power10-1/</source_path>
-		<source_target>i2c-master-dimm45</source_target>
-		<dest_path>ddimm-connector-8/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts1</dest_target>
+		<dest_target>i2c-ocmb-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
 		<default>2</default>
@@ -52197,12 +53651,12 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-dimm45 => ddimm-connector-8/ddimm-0/spd/i2c-slave</bus_id>
+		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-dimm45 => ddimm-connector-8/ddimm-0/spdA/i2c-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-0/godel-0/power10-1/</source_path>
 		<source_target>i2c-master-dimm45</source_target>
-		<dest_path>ddimm-connector-8/ddimm-0/spd/</dest_path>
+		<dest_path>ddimm-connector-8/ddimm-0/spdA/</dest_path>
 		<dest_target>i2c-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
@@ -52234,87 +53688,13 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-op3a => ddimm-connector-9/ddimm-0/ocmb/i2c-ocmb</bus_id>
+		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-op3a => ddimm-connector-9/ddimm-0/ocmb/i2c-ocmb-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-0/godel-0/power10-1/</source_path>
 		<source_target>i2c-master-op3a</source_target>
 		<dest_path>ddimm-connector-9/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ocmb</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-9/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-op3a => ddimm-connector-9/ddimm-0/ocmb/i2c-ts0</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-0/godel-0/power10-1/</source_path>
-		<source_target>i2c-master-op3a</source_target>
-		<dest_path>ddimm-connector-9/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts0</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-9/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-op3a => ddimm-connector-9/ddimm-0/ocmb/i2c-ts1</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-0/godel-0/power10-1/</source_path>
-		<source_target>i2c-master-op3a</source_target>
-		<dest_path>ddimm-connector-9/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts1</dest_target>
+		<dest_target>i2c-ocmb-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
 		<default>2</default>
@@ -52419,12 +53799,12 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-op3a => ddimm-connector-9/ddimm-0/spd/i2c-slave</bus_id>
+		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-op3a => ddimm-connector-9/ddimm-0/spdA/i2c-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-0/godel-0/power10-1/</source_path>
 		<source_target>i2c-master-op3a</source_target>
-		<dest_path>ddimm-connector-9/ddimm-0/spd/</dest_path>
+		<dest_path>ddimm-connector-9/ddimm-0/spdA/</dest_path>
 		<dest_target>i2c-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
@@ -52456,87 +53836,13 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-op5a => ddimm-connector-10/ddimm-0/ocmb/i2c-ocmb</bus_id>
+		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-op5a => ddimm-connector-10/ddimm-0/ocmb/i2c-ocmb-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-0/godel-0/power10-1/</source_path>
 		<source_target>i2c-master-op5a</source_target>
 		<dest_path>ddimm-connector-10/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ocmb</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-10/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-op5a => ddimm-connector-10/ddimm-0/ocmb/i2c-ts0</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-0/godel-0/power10-1/</source_path>
-		<source_target>i2c-master-op5a</source_target>
-		<dest_path>ddimm-connector-10/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts0</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-10/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-op5a => ddimm-connector-10/ddimm-0/ocmb/i2c-ts1</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-0/godel-0/power10-1/</source_path>
-		<source_target>i2c-master-op5a</source_target>
-		<dest_path>ddimm-connector-10/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts1</dest_target>
+		<dest_target>i2c-ocmb-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
 		<default>2</default>
@@ -52641,12 +53947,12 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-op5a => ddimm-connector-10/ddimm-0/spd/i2c-slave</bus_id>
+		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-op5a => ddimm-connector-10/ddimm-0/spdA/i2c-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-0/godel-0/power10-1/</source_path>
 		<source_target>i2c-master-op5a</source_target>
-		<dest_path>ddimm-connector-10/ddimm-0/spd/</dest_path>
+		<dest_path>ddimm-connector-10/ddimm-0/spdA/</dest_path>
 		<dest_target>i2c-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
@@ -52678,87 +53984,13 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-op6b => ddimm-connector-11/ddimm-0/ocmb/i2c-ocmb</bus_id>
+		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-op6b => ddimm-connector-11/ddimm-0/ocmb/i2c-ocmb-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-0/godel-0/power10-1/</source_path>
 		<source_target>i2c-master-op6b</source_target>
 		<dest_path>ddimm-connector-11/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ocmb</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-11/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-op6b => ddimm-connector-11/ddimm-0/ocmb/i2c-ts0</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-0/godel-0/power10-1/</source_path>
-		<source_target>i2c-master-op6b</source_target>
-		<dest_path>ddimm-connector-11/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts0</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-11/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-op6b => ddimm-connector-11/ddimm-0/ocmb/i2c-ts1</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-0/godel-0/power10-1/</source_path>
-		<source_target>i2c-master-op6b</source_target>
-		<dest_path>ddimm-connector-11/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts1</dest_target>
+		<dest_target>i2c-ocmb-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
 		<default>2</default>
@@ -52863,12 +54095,12 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-op6b => ddimm-connector-11/ddimm-0/spd/i2c-slave</bus_id>
+		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-op6b => ddimm-connector-11/ddimm-0/spdA/i2c-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-0/godel-0/power10-1/</source_path>
 		<source_target>i2c-master-op6b</source_target>
-		<dest_path>ddimm-connector-11/ddimm-0/spd/</dest_path>
+		<dest_path>ddimm-connector-11/ddimm-0/spdA/</dest_path>
 		<dest_target>i2c-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
@@ -52900,87 +54132,13 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-op5b => ddimm-connector-12/ddimm-0/ocmb/i2c-ocmb</bus_id>
+		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-op5b => ddimm-connector-12/ddimm-0/ocmb/i2c-ocmb-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-0/godel-0/power10-1/</source_path>
 		<source_target>i2c-master-op5b</source_target>
 		<dest_path>ddimm-connector-12/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ocmb</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-12/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-op5b => ddimm-connector-12/ddimm-0/ocmb/i2c-ts0</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-0/godel-0/power10-1/</source_path>
-		<source_target>i2c-master-op5b</source_target>
-		<dest_path>ddimm-connector-12/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts0</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-12/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-op5b => ddimm-connector-12/ddimm-0/ocmb/i2c-ts1</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-0/godel-0/power10-1/</source_path>
-		<source_target>i2c-master-op5b</source_target>
-		<dest_path>ddimm-connector-12/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts1</dest_target>
+		<dest_target>i2c-ocmb-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
 		<default>2</default>
@@ -53085,12 +54243,12 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-op5b => ddimm-connector-12/ddimm-0/spd/i2c-slave</bus_id>
+		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-op5b => ddimm-connector-12/ddimm-0/spdA/i2c-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-0/godel-0/power10-1/</source_path>
 		<source_target>i2c-master-op5b</source_target>
-		<dest_path>ddimm-connector-12/ddimm-0/spd/</dest_path>
+		<dest_path>ddimm-connector-12/ddimm-0/spdA/</dest_path>
 		<dest_target>i2c-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
@@ -53122,87 +54280,13 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-op3b => ddimm-connector-13/ddimm-0/ocmb/i2c-ocmb</bus_id>
+		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-op3b => ddimm-connector-13/ddimm-0/ocmb/i2c-ocmb-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-0/godel-0/power10-1/</source_path>
 		<source_target>i2c-master-op3b</source_target>
 		<dest_path>ddimm-connector-13/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ocmb</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-13/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-op3b => ddimm-connector-13/ddimm-0/ocmb/i2c-ts0</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-0/godel-0/power10-1/</source_path>
-		<source_target>i2c-master-op3b</source_target>
-		<dest_path>ddimm-connector-13/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts0</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-13/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-op3b => ddimm-connector-13/ddimm-0/ocmb/i2c-ts1</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-0/godel-0/power10-1/</source_path>
-		<source_target>i2c-master-op3b</source_target>
-		<dest_path>ddimm-connector-13/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts1</dest_target>
+		<dest_target>i2c-ocmb-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
 		<default>2</default>
@@ -53307,12 +54391,12 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-op3b => ddimm-connector-13/ddimm-0/spd/i2c-slave</bus_id>
+		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-op3b => ddimm-connector-13/ddimm-0/spdA/i2c-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-0/godel-0/power10-1/</source_path>
 		<source_target>i2c-master-op3b</source_target>
-		<dest_path>ddimm-connector-13/ddimm-0/spd/</dest_path>
+		<dest_path>ddimm-connector-13/ddimm-0/spdA/</dest_path>
 		<dest_target>i2c-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
@@ -53344,87 +54428,13 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-dimm67 => ddimm-connector-14/ddimm-0/ocmb/i2c-ocmb</bus_id>
+		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-dimm67 => ddimm-connector-14/ddimm-0/ocmb/i2c-ocmb-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-0/godel-0/power10-1/</source_path>
 		<source_target>i2c-master-dimm67</source_target>
 		<dest_path>ddimm-connector-14/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ocmb</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-14/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-dimm67 => ddimm-connector-14/ddimm-0/ocmb/i2c-ts0</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-0/godel-0/power10-1/</source_path>
-		<source_target>i2c-master-dimm67</source_target>
-		<dest_path>ddimm-connector-14/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts0</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-14/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-dimm67 => ddimm-connector-14/ddimm-0/ocmb/i2c-ts1</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-0/godel-0/power10-1/</source_path>
-		<source_target>i2c-master-dimm67</source_target>
-		<dest_path>ddimm-connector-14/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts1</dest_target>
+		<dest_target>i2c-ocmb-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
 		<default>2</default>
@@ -53529,12 +54539,12 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-dimm67 => ddimm-connector-14/ddimm-0/spd/i2c-slave</bus_id>
+		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-dimm67 => ddimm-connector-14/ddimm-0/spdA/i2c-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-0/godel-0/power10-1/</source_path>
 		<source_target>i2c-master-dimm67</source_target>
-		<dest_path>ddimm-connector-14/ddimm-0/spd/</dest_path>
+		<dest_path>ddimm-connector-14/ddimm-0/spdA/</dest_path>
 		<dest_target>i2c-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
@@ -53566,87 +54576,13 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-op6a => ddimm-connector-15/ddimm-0/ocmb/i2c-ocmb</bus_id>
+		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-op6a => ddimm-connector-15/ddimm-0/ocmb/i2c-ocmb-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-0/godel-0/power10-1/</source_path>
 		<source_target>i2c-master-op6a</source_target>
 		<dest_path>ddimm-connector-15/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ocmb</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-15/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-op6a => ddimm-connector-15/ddimm-0/ocmb/i2c-ts0</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-0/godel-0/power10-1/</source_path>
-		<source_target>i2c-master-op6a</source_target>
-		<dest_path>ddimm-connector-15/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts0</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-15/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-op6a => ddimm-connector-15/ddimm-0/ocmb/i2c-ts1</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-0/godel-0/power10-1/</source_path>
-		<source_target>i2c-master-op6a</source_target>
-		<dest_path>ddimm-connector-15/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts1</dest_target>
+		<dest_target>i2c-ocmb-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
 		<default>2</default>
@@ -53751,12 +54687,12 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-op6a => ddimm-connector-15/ddimm-0/spd/i2c-slave</bus_id>
+		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-op6a => ddimm-connector-15/ddimm-0/spdA/i2c-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-0/godel-0/power10-1/</source_path>
 		<source_target>i2c-master-op6a</source_target>
-		<dest_path>ddimm-connector-15/ddimm-0/spd/</dest_path>
+		<dest_path>ddimm-connector-15/ddimm-0/spdA/</dest_path>
 		<dest_target>i2c-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
@@ -53788,87 +54724,13 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-op3b => ddimm-connector-16/ddimm-0/ocmb/i2c-ocmb</bus_id>
+		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-op3b => ddimm-connector-16/ddimm-0/ocmb/i2c-ocmb-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-1/godel-0/power10-0/</source_path>
 		<source_target>i2c-master-op3b</source_target>
 		<dest_path>ddimm-connector-16/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ocmb</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-16/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-op3b => ddimm-connector-16/ddimm-0/ocmb/i2c-ts0</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-1/godel-0/power10-0/</source_path>
-		<source_target>i2c-master-op3b</source_target>
-		<dest_path>ddimm-connector-16/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts0</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-16/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-op3b => ddimm-connector-16/ddimm-0/ocmb/i2c-ts1</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-1/godel-0/power10-0/</source_path>
-		<source_target>i2c-master-op3b</source_target>
-		<dest_path>ddimm-connector-16/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts1</dest_target>
+		<dest_target>i2c-ocmb-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
 		<default>2</default>
@@ -53973,12 +54835,12 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-op3b => ddimm-connector-16/ddimm-0/spd/i2c-slave</bus_id>
+		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-op3b => ddimm-connector-16/ddimm-0/spdA/i2c-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-1/godel-0/power10-0/</source_path>
 		<source_target>i2c-master-op3b</source_target>
-		<dest_path>ddimm-connector-16/ddimm-0/spd/</dest_path>
+		<dest_path>ddimm-connector-16/ddimm-0/spdA/</dest_path>
 		<dest_target>i2c-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
@@ -54010,87 +54872,13 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-op3a => ddimm-connector-17/ddimm-0/ocmb/i2c-ocmb</bus_id>
+		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-op3a => ddimm-connector-17/ddimm-0/ocmb/i2c-ocmb-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-1/godel-0/power10-0/</source_path>
 		<source_target>i2c-master-op3a</source_target>
 		<dest_path>ddimm-connector-17/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ocmb</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-17/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-op3a => ddimm-connector-17/ddimm-0/ocmb/i2c-ts0</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-1/godel-0/power10-0/</source_path>
-		<source_target>i2c-master-op3a</source_target>
-		<dest_path>ddimm-connector-17/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts0</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-17/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-op3a => ddimm-connector-17/ddimm-0/ocmb/i2c-ts1</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-1/godel-0/power10-0/</source_path>
-		<source_target>i2c-master-op3a</source_target>
-		<dest_path>ddimm-connector-17/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts1</dest_target>
+		<dest_target>i2c-ocmb-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
 		<default>2</default>
@@ -54195,12 +54983,12 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-op3a => ddimm-connector-17/ddimm-0/spd/i2c-slave</bus_id>
+		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-op3a => ddimm-connector-17/ddimm-0/spdA/i2c-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-1/godel-0/power10-0/</source_path>
 		<source_target>i2c-master-op3a</source_target>
-		<dest_path>ddimm-connector-17/ddimm-0/spd/</dest_path>
+		<dest_path>ddimm-connector-17/ddimm-0/spdA/</dest_path>
 		<dest_target>i2c-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
@@ -54232,87 +55020,13 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-op4a => ddimm-connector-18/ddimm-0/ocmb/i2c-ocmb</bus_id>
+		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-op4a => ddimm-connector-18/ddimm-0/ocmb/i2c-ocmb-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-1/godel-0/power10-0/</source_path>
 		<source_target>i2c-master-op4a</source_target>
 		<dest_path>ddimm-connector-18/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ocmb</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-18/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-op4a => ddimm-connector-18/ddimm-0/ocmb/i2c-ts0</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-1/godel-0/power10-0/</source_path>
-		<source_target>i2c-master-op4a</source_target>
-		<dest_path>ddimm-connector-18/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts0</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-18/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-op4a => ddimm-connector-18/ddimm-0/ocmb/i2c-ts1</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-1/godel-0/power10-0/</source_path>
-		<source_target>i2c-master-op4a</source_target>
-		<dest_path>ddimm-connector-18/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts1</dest_target>
+		<dest_target>i2c-ocmb-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
 		<default>2</default>
@@ -54417,12 +55131,12 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-op4a => ddimm-connector-18/ddimm-0/spd/i2c-slave</bus_id>
+		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-op4a => ddimm-connector-18/ddimm-0/spdA/i2c-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-1/godel-0/power10-0/</source_path>
 		<source_target>i2c-master-op4a</source_target>
-		<dest_path>ddimm-connector-18/ddimm-0/spd/</dest_path>
+		<dest_path>ddimm-connector-18/ddimm-0/spdA/</dest_path>
 		<dest_target>i2c-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
@@ -54454,87 +55168,13 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-op4b => ddimm-connector-19/ddimm-0/ocmb/i2c-ocmb</bus_id>
+		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-op4b => ddimm-connector-19/ddimm-0/ocmb/i2c-ocmb-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-1/godel-0/power10-0/</source_path>
 		<source_target>i2c-master-op4b</source_target>
 		<dest_path>ddimm-connector-19/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ocmb</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-19/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-op4b => ddimm-connector-19/ddimm-0/ocmb/i2c-ts0</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-1/godel-0/power10-0/</source_path>
-		<source_target>i2c-master-op4b</source_target>
-		<dest_path>ddimm-connector-19/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts0</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-19/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-op4b => ddimm-connector-19/ddimm-0/ocmb/i2c-ts1</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-1/godel-0/power10-0/</source_path>
-		<source_target>i2c-master-op4b</source_target>
-		<dest_path>ddimm-connector-19/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts1</dest_target>
+		<dest_target>i2c-ocmb-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
 		<default>2</default>
@@ -54639,12 +55279,12 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-op4b => ddimm-connector-19/ddimm-0/spd/i2c-slave</bus_id>
+		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-op4b => ddimm-connector-19/ddimm-0/spdA/i2c-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-1/godel-0/power10-0/</source_path>
 		<source_target>i2c-master-op4b</source_target>
-		<dest_path>ddimm-connector-19/ddimm-0/spd/</dest_path>
+		<dest_path>ddimm-connector-19/ddimm-0/spdA/</dest_path>
 		<dest_target>i2c-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
@@ -54676,87 +55316,13 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-op5b => ddimm-connector-20/ddimm-0/ocmb/i2c-ocmb</bus_id>
+		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-op5b => ddimm-connector-20/ddimm-0/ocmb/i2c-ocmb-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-1/godel-0/power10-0/</source_path>
 		<source_target>i2c-master-op5b</source_target>
 		<dest_path>ddimm-connector-20/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ocmb</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-20/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-op5b => ddimm-connector-20/ddimm-0/ocmb/i2c-ts0</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-1/godel-0/power10-0/</source_path>
-		<source_target>i2c-master-op5b</source_target>
-		<dest_path>ddimm-connector-20/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts0</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-20/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-op5b => ddimm-connector-20/ddimm-0/ocmb/i2c-ts1</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-1/godel-0/power10-0/</source_path>
-		<source_target>i2c-master-op5b</source_target>
-		<dest_path>ddimm-connector-20/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts1</dest_target>
+		<dest_target>i2c-ocmb-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
 		<default>2</default>
@@ -54861,12 +55427,12 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-op5b => ddimm-connector-20/ddimm-0/spd/i2c-slave</bus_id>
+		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-op5b => ddimm-connector-20/ddimm-0/spdA/i2c-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-1/godel-0/power10-0/</source_path>
 		<source_target>i2c-master-op5b</source_target>
-		<dest_path>ddimm-connector-20/ddimm-0/spd/</dest_path>
+		<dest_path>ddimm-connector-20/ddimm-0/spdA/</dest_path>
 		<dest_target>i2c-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
@@ -54898,87 +55464,13 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-dimm01 => ddimm-connector-21/ddimm-0/ocmb/i2c-ocmb</bus_id>
+		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-dimm01 => ddimm-connector-21/ddimm-0/ocmb/i2c-ocmb-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-1/godel-0/power10-0/</source_path>
 		<source_target>i2c-master-dimm01</source_target>
 		<dest_path>ddimm-connector-21/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ocmb</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-21/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-dimm01 => ddimm-connector-21/ddimm-0/ocmb/i2c-ts0</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-1/godel-0/power10-0/</source_path>
-		<source_target>i2c-master-dimm01</source_target>
-		<dest_path>ddimm-connector-21/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts0</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-21/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-dimm01 => ddimm-connector-21/ddimm-0/ocmb/i2c-ts1</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-1/godel-0/power10-0/</source_path>
-		<source_target>i2c-master-dimm01</source_target>
-		<dest_path>ddimm-connector-21/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts1</dest_target>
+		<dest_target>i2c-ocmb-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
 		<default>2</default>
@@ -55083,12 +55575,12 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-dimm01 => ddimm-connector-21/ddimm-0/spd/i2c-slave</bus_id>
+		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-dimm01 => ddimm-connector-21/ddimm-0/spdA/i2c-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-1/godel-0/power10-0/</source_path>
 		<source_target>i2c-master-dimm01</source_target>
-		<dest_path>ddimm-connector-21/ddimm-0/spd/</dest_path>
+		<dest_path>ddimm-connector-21/ddimm-0/spdA/</dest_path>
 		<dest_target>i2c-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
@@ -55120,87 +55612,13 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-op5a => ddimm-connector-22/ddimm-0/ocmb/i2c-ocmb</bus_id>
+		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-op5a => ddimm-connector-22/ddimm-0/ocmb/i2c-ocmb-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-1/godel-0/power10-0/</source_path>
 		<source_target>i2c-master-op5a</source_target>
 		<dest_path>ddimm-connector-22/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ocmb</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-22/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-op5a => ddimm-connector-22/ddimm-0/ocmb/i2c-ts0</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-1/godel-0/power10-0/</source_path>
-		<source_target>i2c-master-op5a</source_target>
-		<dest_path>ddimm-connector-22/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts0</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-22/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-op5a => ddimm-connector-22/ddimm-0/ocmb/i2c-ts1</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-1/godel-0/power10-0/</source_path>
-		<source_target>i2c-master-op5a</source_target>
-		<dest_path>ddimm-connector-22/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts1</dest_target>
+		<dest_target>i2c-ocmb-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
 		<default>2</default>
@@ -55305,12 +55723,12 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-op5a => ddimm-connector-22/ddimm-0/spd/i2c-slave</bus_id>
+		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-op5a => ddimm-connector-22/ddimm-0/spdA/i2c-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-1/godel-0/power10-0/</source_path>
 		<source_target>i2c-master-op5a</source_target>
-		<dest_path>ddimm-connector-22/ddimm-0/spd/</dest_path>
+		<dest_path>ddimm-connector-22/ddimm-0/spdA/</dest_path>
 		<dest_target>i2c-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
@@ -55342,87 +55760,13 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-dimm23 => ddimm-connector-23/ddimm-0/ocmb/i2c-ocmb</bus_id>
+		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-dimm23 => ddimm-connector-23/ddimm-0/ocmb/i2c-ocmb-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-1/godel-0/power10-0/</source_path>
 		<source_target>i2c-master-dimm23</source_target>
 		<dest_path>ddimm-connector-23/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ocmb</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-23/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-dimm23 => ddimm-connector-23/ddimm-0/ocmb/i2c-ts0</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-1/godel-0/power10-0/</source_path>
-		<source_target>i2c-master-dimm23</source_target>
-		<dest_path>ddimm-connector-23/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts0</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-23/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-dimm23 => ddimm-connector-23/ddimm-0/ocmb/i2c-ts1</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-1/godel-0/power10-0/</source_path>
-		<source_target>i2c-master-dimm23</source_target>
-		<dest_path>ddimm-connector-23/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts1</dest_target>
+		<dest_target>i2c-ocmb-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
 		<default>2</default>
@@ -55527,12 +55871,12 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-dimm23 => ddimm-connector-23/ddimm-0/spd/i2c-slave</bus_id>
+		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-dimm23 => ddimm-connector-23/ddimm-0/spdA/i2c-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-1/godel-0/power10-0/</source_path>
 		<source_target>i2c-master-dimm23</source_target>
-		<dest_path>ddimm-connector-23/ddimm-0/spd/</dest_path>
+		<dest_path>ddimm-connector-23/ddimm-0/spdA/</dest_path>
 		<dest_target>i2c-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
@@ -55564,87 +55908,13 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-dimm45 => ddimm-connector-24/ddimm-0/ocmb/i2c-ocmb</bus_id>
+		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-dimm45 => ddimm-connector-24/ddimm-0/ocmb/i2c-ocmb-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-1/godel-0/power10-1/</source_path>
 		<source_target>i2c-master-dimm45</source_target>
 		<dest_path>ddimm-connector-24/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ocmb</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-24/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-dimm45 => ddimm-connector-24/ddimm-0/ocmb/i2c-ts0</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-1/godel-0/power10-1/</source_path>
-		<source_target>i2c-master-dimm45</source_target>
-		<dest_path>ddimm-connector-24/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts0</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-24/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-dimm45 => ddimm-connector-24/ddimm-0/ocmb/i2c-ts1</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-1/godel-0/power10-1/</source_path>
-		<source_target>i2c-master-dimm45</source_target>
-		<dest_path>ddimm-connector-24/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts1</dest_target>
+		<dest_target>i2c-ocmb-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
 		<default>2</default>
@@ -55749,12 +56019,12 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-dimm45 => ddimm-connector-24/ddimm-0/spd/i2c-slave</bus_id>
+		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-dimm45 => ddimm-connector-24/ddimm-0/spdA/i2c-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-1/godel-0/power10-1/</source_path>
 		<source_target>i2c-master-dimm45</source_target>
-		<dest_path>ddimm-connector-24/ddimm-0/spd/</dest_path>
+		<dest_path>ddimm-connector-24/ddimm-0/spdA/</dest_path>
 		<dest_target>i2c-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
@@ -55786,87 +56056,13 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-op3a => ddimm-connector-25/ddimm-0/ocmb/i2c-ocmb</bus_id>
+		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-op3a => ddimm-connector-25/ddimm-0/ocmb/i2c-ocmb-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-1/godel-0/power10-1/</source_path>
 		<source_target>i2c-master-op3a</source_target>
 		<dest_path>ddimm-connector-25/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ocmb</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-25/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-op3a => ddimm-connector-25/ddimm-0/ocmb/i2c-ts0</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-1/godel-0/power10-1/</source_path>
-		<source_target>i2c-master-op3a</source_target>
-		<dest_path>ddimm-connector-25/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts0</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-25/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-op3a => ddimm-connector-25/ddimm-0/ocmb/i2c-ts1</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-1/godel-0/power10-1/</source_path>
-		<source_target>i2c-master-op3a</source_target>
-		<dest_path>ddimm-connector-25/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts1</dest_target>
+		<dest_target>i2c-ocmb-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
 		<default>2</default>
@@ -55971,12 +56167,12 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-op3a => ddimm-connector-25/ddimm-0/spd/i2c-slave</bus_id>
+		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-op3a => ddimm-connector-25/ddimm-0/spdA/i2c-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-1/godel-0/power10-1/</source_path>
 		<source_target>i2c-master-op3a</source_target>
-		<dest_path>ddimm-connector-25/ddimm-0/spd/</dest_path>
+		<dest_path>ddimm-connector-25/ddimm-0/spdA/</dest_path>
 		<dest_target>i2c-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
@@ -56008,87 +56204,13 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-op5a => ddimm-connector-26/ddimm-0/ocmb/i2c-ocmb</bus_id>
+		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-op5a => ddimm-connector-26/ddimm-0/ocmb/i2c-ocmb-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-1/godel-0/power10-1/</source_path>
 		<source_target>i2c-master-op5a</source_target>
 		<dest_path>ddimm-connector-26/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ocmb</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-26/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-op5a => ddimm-connector-26/ddimm-0/ocmb/i2c-ts0</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-1/godel-0/power10-1/</source_path>
-		<source_target>i2c-master-op5a</source_target>
-		<dest_path>ddimm-connector-26/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts0</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-26/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-op5a => ddimm-connector-26/ddimm-0/ocmb/i2c-ts1</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-1/godel-0/power10-1/</source_path>
-		<source_target>i2c-master-op5a</source_target>
-		<dest_path>ddimm-connector-26/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts1</dest_target>
+		<dest_target>i2c-ocmb-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
 		<default>2</default>
@@ -56193,12 +56315,12 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-op5a => ddimm-connector-26/ddimm-0/spd/i2c-slave</bus_id>
+		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-op5a => ddimm-connector-26/ddimm-0/spdA/i2c-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-1/godel-0/power10-1/</source_path>
 		<source_target>i2c-master-op5a</source_target>
-		<dest_path>ddimm-connector-26/ddimm-0/spd/</dest_path>
+		<dest_path>ddimm-connector-26/ddimm-0/spdA/</dest_path>
 		<dest_target>i2c-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
@@ -56230,87 +56352,13 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-op6b => ddimm-connector-27/ddimm-0/ocmb/i2c-ocmb</bus_id>
+		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-op6b => ddimm-connector-27/ddimm-0/ocmb/i2c-ocmb-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-1/godel-0/power10-1/</source_path>
 		<source_target>i2c-master-op6b</source_target>
 		<dest_path>ddimm-connector-27/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ocmb</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-27/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-op6b => ddimm-connector-27/ddimm-0/ocmb/i2c-ts0</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-1/godel-0/power10-1/</source_path>
-		<source_target>i2c-master-op6b</source_target>
-		<dest_path>ddimm-connector-27/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts0</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-27/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-op6b => ddimm-connector-27/ddimm-0/ocmb/i2c-ts1</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-1/godel-0/power10-1/</source_path>
-		<source_target>i2c-master-op6b</source_target>
-		<dest_path>ddimm-connector-27/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts1</dest_target>
+		<dest_target>i2c-ocmb-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
 		<default>2</default>
@@ -56415,12 +56463,12 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-op6b => ddimm-connector-27/ddimm-0/spd/i2c-slave</bus_id>
+		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-op6b => ddimm-connector-27/ddimm-0/spdA/i2c-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-1/godel-0/power10-1/</source_path>
 		<source_target>i2c-master-op6b</source_target>
-		<dest_path>ddimm-connector-27/ddimm-0/spd/</dest_path>
+		<dest_path>ddimm-connector-27/ddimm-0/spdA/</dest_path>
 		<dest_target>i2c-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
@@ -56452,87 +56500,13 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-op5b => ddimm-connector-28/ddimm-0/ocmb/i2c-ocmb</bus_id>
+		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-op5b => ddimm-connector-28/ddimm-0/ocmb/i2c-ocmb-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-1/godel-0/power10-1/</source_path>
 		<source_target>i2c-master-op5b</source_target>
 		<dest_path>ddimm-connector-28/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ocmb</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-28/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-op5b => ddimm-connector-28/ddimm-0/ocmb/i2c-ts0</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-1/godel-0/power10-1/</source_path>
-		<source_target>i2c-master-op5b</source_target>
-		<dest_path>ddimm-connector-28/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts0</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-28/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-op5b => ddimm-connector-28/ddimm-0/ocmb/i2c-ts1</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-1/godel-0/power10-1/</source_path>
-		<source_target>i2c-master-op5b</source_target>
-		<dest_path>ddimm-connector-28/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts1</dest_target>
+		<dest_target>i2c-ocmb-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
 		<default>2</default>
@@ -56637,12 +56611,12 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-op5b => ddimm-connector-28/ddimm-0/spd/i2c-slave</bus_id>
+		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-op5b => ddimm-connector-28/ddimm-0/spdA/i2c-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-1/godel-0/power10-1/</source_path>
 		<source_target>i2c-master-op5b</source_target>
-		<dest_path>ddimm-connector-28/ddimm-0/spd/</dest_path>
+		<dest_path>ddimm-connector-28/ddimm-0/spdA/</dest_path>
 		<dest_target>i2c-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
@@ -56674,87 +56648,13 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-op3b => ddimm-connector-29/ddimm-0/ocmb/i2c-ocmb</bus_id>
+		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-op3b => ddimm-connector-29/ddimm-0/ocmb/i2c-ocmb-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-1/godel-0/power10-1/</source_path>
 		<source_target>i2c-master-op3b</source_target>
 		<dest_path>ddimm-connector-29/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ocmb</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-29/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-op3b => ddimm-connector-29/ddimm-0/ocmb/i2c-ts0</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-1/godel-0/power10-1/</source_path>
-		<source_target>i2c-master-op3b</source_target>
-		<dest_path>ddimm-connector-29/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts0</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-29/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-op3b => ddimm-connector-29/ddimm-0/ocmb/i2c-ts1</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-1/godel-0/power10-1/</source_path>
-		<source_target>i2c-master-op3b</source_target>
-		<dest_path>ddimm-connector-29/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts1</dest_target>
+		<dest_target>i2c-ocmb-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
 		<default>2</default>
@@ -56859,12 +56759,12 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-op3b => ddimm-connector-29/ddimm-0/spd/i2c-slave</bus_id>
+		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-op3b => ddimm-connector-29/ddimm-0/spdA/i2c-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-1/godel-0/power10-1/</source_path>
 		<source_target>i2c-master-op3b</source_target>
-		<dest_path>ddimm-connector-29/ddimm-0/spd/</dest_path>
+		<dest_path>ddimm-connector-29/ddimm-0/spdA/</dest_path>
 		<dest_target>i2c-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
@@ -56896,87 +56796,13 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-dimm67 => ddimm-connector-30/ddimm-0/ocmb/i2c-ocmb</bus_id>
+		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-dimm67 => ddimm-connector-30/ddimm-0/ocmb/i2c-ocmb-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-1/godel-0/power10-1/</source_path>
 		<source_target>i2c-master-dimm67</source_target>
 		<dest_path>ddimm-connector-30/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ocmb</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-30/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-dimm67 => ddimm-connector-30/ddimm-0/ocmb/i2c-ts0</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-1/godel-0/power10-1/</source_path>
-		<source_target>i2c-master-dimm67</source_target>
-		<dest_path>ddimm-connector-30/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts0</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-30/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-dimm67 => ddimm-connector-30/ddimm-0/ocmb/i2c-ts1</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-1/godel-0/power10-1/</source_path>
-		<source_target>i2c-master-dimm67</source_target>
-		<dest_path>ddimm-connector-30/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts1</dest_target>
+		<dest_target>i2c-ocmb-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
 		<default>2</default>
@@ -57081,12 +56907,12 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-dimm67 => ddimm-connector-30/ddimm-0/spd/i2c-slave</bus_id>
+		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-dimm67 => ddimm-connector-30/ddimm-0/spdA/i2c-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-1/godel-0/power10-1/</source_path>
 		<source_target>i2c-master-dimm67</source_target>
-		<dest_path>ddimm-connector-30/ddimm-0/spd/</dest_path>
+		<dest_path>ddimm-connector-30/ddimm-0/spdA/</dest_path>
 		<dest_target>i2c-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
@@ -57118,87 +56944,13 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-op6a => ddimm-connector-31/ddimm-0/ocmb/i2c-ocmb</bus_id>
+		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-op6a => ddimm-connector-31/ddimm-0/ocmb/i2c-ocmb-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-1/godel-0/power10-1/</source_path>
 		<source_target>i2c-master-op6a</source_target>
 		<dest_path>ddimm-connector-31/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ocmb</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-31/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-op6a => ddimm-connector-31/ddimm-0/ocmb/i2c-ts0</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-1/godel-0/power10-1/</source_path>
-		<source_target>i2c-master-op6a</source_target>
-		<dest_path>ddimm-connector-31/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts0</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>FRU_PATH</id>
-		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-31/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_BUS_ALIAS</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_PURPOSE</id>
-		<default></default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_TYPE</id>
-		<default></default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-op6a => ddimm-connector-31/ddimm-0/ocmb/i2c-ts1</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-1/godel-0/power10-1/</source_path>
-		<source_target>i2c-master-op6a</source_target>
-		<dest_path>ddimm-connector-31/ddimm-0/ocmb/</dest_path>
-		<dest_target>i2c-ts1</dest_target>
+		<dest_target>i2c-ocmb-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
 		<default>2</default>
@@ -57303,12 +57055,12 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-op6a => ddimm-connector-31/ddimm-0/spd/i2c-slave</bus_id>
+		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-op6a => ddimm-connector-31/ddimm-0/spdA/i2c-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-1/godel-0/power10-1/</source_path>
 		<source_target>i2c-master-op6a</source_target>
-		<dest_path>ddimm-connector-31/ddimm-0/spd/</dest_path>
+		<dest_path>ddimm-connector-31/ddimm-0/spdA/</dest_path>
 		<dest_target>i2c-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
@@ -60022,6 +59774,4742 @@
 		<bus_attribute>
 			<id>FRU_PATH</id>
 		<default>H:/sys-0/node-0/nisqually-0/ebmc-card-connector-0/ingraham-0(BMC-0),L:/sys-0/node-0/nisqually-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-op3b => ddimm-connector-0/ddimm-0/spdB/i2c-slave</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-0/godel-0/power10-0/</source_path>
+		<source_target>i2c-master-op3b</source_target>
+		<dest_path>ddimm-connector-0/ddimm-0/spdB/</dest_path>
+		<dest_target>i2c-slave</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-0/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-op3a => ddimm-connector-1/ddimm-0/spdB/i2c-slave</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-0/godel-0/power10-0/</source_path>
+		<source_target>i2c-master-op3a</source_target>
+		<dest_path>ddimm-connector-1/ddimm-0/spdB/</dest_path>
+		<dest_target>i2c-slave</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-1/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-op4a => ddimm-connector-2/ddimm-0/spdB/i2c-slave</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-0/godel-0/power10-0/</source_path>
+		<source_target>i2c-master-op4a</source_target>
+		<dest_path>ddimm-connector-2/ddimm-0/spdB/</dest_path>
+		<dest_target>i2c-slave</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-2/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-op4b => ddimm-connector-3/ddimm-0/spdB/i2c-slave</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-0/godel-0/power10-0/</source_path>
+		<source_target>i2c-master-op4b</source_target>
+		<dest_path>ddimm-connector-3/ddimm-0/spdB/</dest_path>
+		<dest_target>i2c-slave</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-3/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-op5b => ddimm-connector-4/ddimm-0/spdB/i2c-slave</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-0/godel-0/power10-0/</source_path>
+		<source_target>i2c-master-op5b</source_target>
+		<dest_path>ddimm-connector-4/ddimm-0/spdB/</dest_path>
+		<dest_target>i2c-slave</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-4/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-dimm01 => ddimm-connector-5/ddimm-0/spdB/i2c-slave</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-0/godel-0/power10-0/</source_path>
+		<source_target>i2c-master-dimm01</source_target>
+		<dest_path>ddimm-connector-5/ddimm-0/spdB/</dest_path>
+		<dest_target>i2c-slave</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-5/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-op5a => ddimm-connector-6/ddimm-0/spdB/i2c-slave</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-0/godel-0/power10-0/</source_path>
+		<source_target>i2c-master-op5a</source_target>
+		<dest_path>ddimm-connector-6/ddimm-0/spdB/</dest_path>
+		<dest_target>i2c-slave</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-6/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-0/godel-0/power10-0/i2c-master-dimm23 => ddimm-connector-7/ddimm-0/spdB/i2c-slave</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-0/godel-0/power10-0/</source_path>
+		<source_target>i2c-master-dimm23</source_target>
+		<dest_path>ddimm-connector-7/ddimm-0/spdB/</dest_path>
+		<dest_target>i2c-slave</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-7/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-dimm45 => ddimm-connector-8/ddimm-0/spdB/i2c-slave</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-0/godel-0/power10-1/</source_path>
+		<source_target>i2c-master-dimm45</source_target>
+		<dest_path>ddimm-connector-8/ddimm-0/spdB/</dest_path>
+		<dest_target>i2c-slave</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-8/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-op3a => ddimm-connector-9/ddimm-0/spdB/i2c-slave</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-0/godel-0/power10-1/</source_path>
+		<source_target>i2c-master-op3a</source_target>
+		<dest_path>ddimm-connector-9/ddimm-0/spdB/</dest_path>
+		<dest_target>i2c-slave</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-9/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-op5a => ddimm-connector-10/ddimm-0/spdB/i2c-slave</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-0/godel-0/power10-1/</source_path>
+		<source_target>i2c-master-op5a</source_target>
+		<dest_path>ddimm-connector-10/ddimm-0/spdB/</dest_path>
+		<dest_target>i2c-slave</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-10/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-op6b => ddimm-connector-11/ddimm-0/spdB/i2c-slave</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-0/godel-0/power10-1/</source_path>
+		<source_target>i2c-master-op6b</source_target>
+		<dest_path>ddimm-connector-11/ddimm-0/spdB/</dest_path>
+		<dest_target>i2c-slave</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-11/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-op5b => ddimm-connector-12/ddimm-0/spdB/i2c-slave</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-0/godel-0/power10-1/</source_path>
+		<source_target>i2c-master-op5b</source_target>
+		<dest_path>ddimm-connector-12/ddimm-0/spdB/</dest_path>
+		<dest_target>i2c-slave</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-12/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-op3b => ddimm-connector-13/ddimm-0/spdB/i2c-slave</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-0/godel-0/power10-1/</source_path>
+		<source_target>i2c-master-op3b</source_target>
+		<dest_path>ddimm-connector-13/ddimm-0/spdB/</dest_path>
+		<dest_target>i2c-slave</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-13/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-dimm67 => ddimm-connector-14/ddimm-0/spdB/i2c-slave</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-0/godel-0/power10-1/</source_path>
+		<source_target>i2c-master-dimm67</source_target>
+		<dest_path>ddimm-connector-14/ddimm-0/spdB/</dest_path>
+		<dest_target>i2c-slave</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-14/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-0/godel-0/power10-1/i2c-master-op6a => ddimm-connector-15/ddimm-0/spdB/i2c-slave</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-0/godel-0/power10-1/</source_path>
+		<source_target>i2c-master-op6a</source_target>
+		<dest_path>ddimm-connector-15/ddimm-0/spdB/</dest_path>
+		<dest_target>i2c-slave</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-15/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-0/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-op3b => ddimm-connector-16/ddimm-0/spdB/i2c-slave</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-1/godel-0/power10-0/</source_path>
+		<source_target>i2c-master-op3b</source_target>
+		<dest_path>ddimm-connector-16/ddimm-0/spdB/</dest_path>
+		<dest_target>i2c-slave</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-16/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-op3a => ddimm-connector-17/ddimm-0/spdB/i2c-slave</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-1/godel-0/power10-0/</source_path>
+		<source_target>i2c-master-op3a</source_target>
+		<dest_path>ddimm-connector-17/ddimm-0/spdB/</dest_path>
+		<dest_target>i2c-slave</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-17/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-op4a => ddimm-connector-18/ddimm-0/spdB/i2c-slave</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-1/godel-0/power10-0/</source_path>
+		<source_target>i2c-master-op4a</source_target>
+		<dest_path>ddimm-connector-18/ddimm-0/spdB/</dest_path>
+		<dest_target>i2c-slave</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-18/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-op4b => ddimm-connector-19/ddimm-0/spdB/i2c-slave</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-1/godel-0/power10-0/</source_path>
+		<source_target>i2c-master-op4b</source_target>
+		<dest_path>ddimm-connector-19/ddimm-0/spdB/</dest_path>
+		<dest_target>i2c-slave</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-19/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-op5b => ddimm-connector-20/ddimm-0/spdB/i2c-slave</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-1/godel-0/power10-0/</source_path>
+		<source_target>i2c-master-op5b</source_target>
+		<dest_path>ddimm-connector-20/ddimm-0/spdB/</dest_path>
+		<dest_target>i2c-slave</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-20/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-dimm01 => ddimm-connector-21/ddimm-0/spdB/i2c-slave</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-1/godel-0/power10-0/</source_path>
+		<source_target>i2c-master-dimm01</source_target>
+		<dest_path>ddimm-connector-21/ddimm-0/spdB/</dest_path>
+		<dest_target>i2c-slave</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-21/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-op5a => ddimm-connector-22/ddimm-0/spdB/i2c-slave</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-1/godel-0/power10-0/</source_path>
+		<source_target>i2c-master-op5a</source_target>
+		<dest_path>ddimm-connector-22/ddimm-0/spdB/</dest_path>
+		<dest_target>i2c-slave</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-22/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-1/godel-0/power10-0/i2c-master-dimm23 => ddimm-connector-23/ddimm-0/spdB/i2c-slave</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-1/godel-0/power10-0/</source_path>
+		<source_target>i2c-master-dimm23</source_target>
+		<dest_path>ddimm-connector-23/ddimm-0/spdB/</dest_path>
+		<dest_target>i2c-slave</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-23/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-dimm45 => ddimm-connector-24/ddimm-0/spdB/i2c-slave</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-1/godel-0/power10-1/</source_path>
+		<source_target>i2c-master-dimm45</source_target>
+		<dest_path>ddimm-connector-24/ddimm-0/spdB/</dest_path>
+		<dest_target>i2c-slave</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-24/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-op3a => ddimm-connector-25/ddimm-0/spdB/i2c-slave</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-1/godel-0/power10-1/</source_path>
+		<source_target>i2c-master-op3a</source_target>
+		<dest_path>ddimm-connector-25/ddimm-0/spdB/</dest_path>
+		<dest_target>i2c-slave</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-25/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-op5a => ddimm-connector-26/ddimm-0/spdB/i2c-slave</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-1/godel-0/power10-1/</source_path>
+		<source_target>i2c-master-op5a</source_target>
+		<dest_path>ddimm-connector-26/ddimm-0/spdB/</dest_path>
+		<dest_target>i2c-slave</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-26/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-op6b => ddimm-connector-27/ddimm-0/spdB/i2c-slave</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-1/godel-0/power10-1/</source_path>
+		<source_target>i2c-master-op6b</source_target>
+		<dest_path>ddimm-connector-27/ddimm-0/spdB/</dest_path>
+		<dest_target>i2c-slave</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-27/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-op5b => ddimm-connector-28/ddimm-0/spdB/i2c-slave</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-1/godel-0/power10-1/</source_path>
+		<source_target>i2c-master-op5b</source_target>
+		<dest_path>ddimm-connector-28/ddimm-0/spdB/</dest_path>
+		<dest_target>i2c-slave</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-28/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-op3b => ddimm-connector-29/ddimm-0/spdB/i2c-slave</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-1/godel-0/power10-1/</source_path>
+		<source_target>i2c-master-op3b</source_target>
+		<dest_path>ddimm-connector-29/ddimm-0/spdB/</dest_path>
+		<dest_target>i2c-slave</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-29/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-dimm67 => ddimm-connector-30/ddimm-0/spdB/i2c-slave</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-1/godel-0/power10-1/</source_path>
+		<source_target>i2c-master-dimm67</source_target>
+		<dest_path>ddimm-connector-30/ddimm-0/spdB/</dest_path>
+		<dest_target>i2c-slave</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-30/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-1/godel-0/power10-1/i2c-master-op6a => ddimm-connector-31/ddimm-0/spdB/i2c-slave</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-1/godel-0/power10-1/</source_path>
+		<source_target>i2c-master-op6a</source_target>
+		<dest_path>ddimm-connector-31/ddimm-0/spdB/</dest_path>
+		<dest_target>i2c-slave</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>L:/sys-0/node-0/nisqually-0,H:/sys-0/node-0/nisqually-0/ddimm-connector-31/ddimm-0,H:/sys-0/node-0/nisqually-0/proc_socket-1/godel-0(power10)</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-0/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-0/ddimm-0/ocmb/i2c-ts0</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-0/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-0/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts0</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-0/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-0/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-0/ddimm-0/ocmb/i2c-ts1</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-0/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-0/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts1</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-0/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-0/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-0/ddimm-0/ocmb/i2c-ts2</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-0/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-0/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts2</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-0/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-1/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-1/ddimm-0/ocmb/i2c-ts0</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-1/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-1/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts0</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-1/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-1/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-1/ddimm-0/ocmb/i2c-ts1</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-1/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-1/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts1</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-1/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-1/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-1/ddimm-0/ocmb/i2c-ts2</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-1/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-1/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts2</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-1/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-2/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-2/ddimm-0/ocmb/i2c-ts0</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-2/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-2/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts0</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-2/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-2/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-2/ddimm-0/ocmb/i2c-ts1</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-2/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-2/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts1</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-2/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-2/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-2/ddimm-0/ocmb/i2c-ts2</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-2/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-2/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts2</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-2/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-3/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-3/ddimm-0/ocmb/i2c-ts0</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-3/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-3/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts0</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-3/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-3/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-3/ddimm-0/ocmb/i2c-ts1</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-3/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-3/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts1</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-3/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-3/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-3/ddimm-0/ocmb/i2c-ts2</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-3/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-3/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts2</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>null</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-3/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-4/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-4/ddimm-0/ocmb/i2c-ts0</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-4/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-4/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts0</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-4/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-4/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-4/ddimm-0/ocmb/i2c-ts1</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-4/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-4/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts1</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-4/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-4/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-4/ddimm-0/ocmb/i2c-ts2</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-4/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-4/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts2</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-4/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-5/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-5/ddimm-0/ocmb/i2c-ts0</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-5/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-5/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts0</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-5/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-5/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-5/ddimm-0/ocmb/i2c-ts1</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-5/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-5/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts1</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-5/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-5/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-5/ddimm-0/ocmb/i2c-ts2</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-5/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-5/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts2</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-5/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-6/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-6/ddimm-0/ocmb/i2c-ts0</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-6/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-6/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts0</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-6/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-6/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-6/ddimm-0/ocmb/i2c-ts1</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-6/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-6/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts1</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-6/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-6/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-6/ddimm-0/ocmb/i2c-ts2</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-6/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-6/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts2</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-6/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-7/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-7/ddimm-0/ocmb/i2c-ts0</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-7/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-7/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts0</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-7/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-7/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-7/ddimm-0/ocmb/i2c-ts1</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-7/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-7/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts1</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-7/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-7/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-7/ddimm-0/ocmb/i2c-ts2</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-7/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-7/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts2</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-7/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-8/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-8/ddimm-0/ocmb/i2c-ts0</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-8/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-8/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts0</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-8/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-8/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-8/ddimm-0/ocmb/i2c-ts1</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-8/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-8/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts1</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-8/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-8/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-8/ddimm-0/ocmb/i2c-ts2</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-8/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-8/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts2</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-8/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-9/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-9/ddimm-0/ocmb/i2c-ts0</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-9/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-9/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts0</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-9/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-9/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-9/ddimm-0/ocmb/i2c-ts1</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-9/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-9/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts1</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-9/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-9/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-9/ddimm-0/ocmb/i2c-ts2</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-9/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-9/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts2</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-9/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-10/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-10/ddimm-0/ocmb/i2c-ts0</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-10/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-10/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts0</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-10/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-10/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-10/ddimm-0/ocmb/i2c-ts1</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-10/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-10/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts1</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-10/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-10/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-10/ddimm-0/ocmb/i2c-ts2</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-10/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-10/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts2</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-10/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-11/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-11/ddimm-0/ocmb/i2c-ts0</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-11/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-11/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts0</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-11/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-11/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-11/ddimm-0/ocmb/i2c-ts1</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-11/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-11/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts1</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-11/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-11/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-11/ddimm-0/ocmb/i2c-ts2</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-11/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-11/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts2</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-11/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-12/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-12/ddimm-0/ocmb/i2c-ts0</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-12/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-12/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts0</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-12/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-12/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-12/ddimm-0/ocmb/i2c-ts1</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-12/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-12/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts1</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-12/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-12/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-12/ddimm-0/ocmb/i2c-ts2</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-12/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-12/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts2</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-12/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-13/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-13/ddimm-0/ocmb/i2c-ts0</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-13/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-13/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts0</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-13/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-13/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-13/ddimm-0/ocmb/i2c-ts1</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-13/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-13/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts1</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-13/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-13/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-13/ddimm-0/ocmb/i2c-ts2</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-13/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-13/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts2</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-13/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-14/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-14/ddimm-0/ocmb/i2c-ts0</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-14/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-14/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts0</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-14/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-14/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-14/ddimm-0/ocmb/i2c-ts1</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-14/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-14/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts1</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-14/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-14/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-14/ddimm-0/ocmb/i2c-ts2</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-14/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-14/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts2</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-14/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-15/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-15/ddimm-0/ocmb/i2c-ts0</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-15/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-15/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts0</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-15/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-15/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-15/ddimm-0/ocmb/i2c-ts1</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-15/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-15/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts1</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-15/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-15/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-15/ddimm-0/ocmb/i2c-ts2</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-15/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-15/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts2</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-15/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-16/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-16/ddimm-0/ocmb/i2c-ts0</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-16/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-16/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts0</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-16/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-16/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-16/ddimm-0/ocmb/i2c-ts1</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-16/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-16/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts1</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-16/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-16/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-16/ddimm-0/ocmb/i2c-ts2</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-16/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-16/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts2</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-16/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-17/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-17/ddimm-0/ocmb/i2c-ts0</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-17/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-17/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts0</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-17/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-17/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-17/ddimm-0/ocmb/i2c-ts1</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-17/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-17/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts1</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-17/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-17/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-17/ddimm-0/ocmb/i2c-ts2</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-17/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-17/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts2</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-17/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-18/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-18/ddimm-0/ocmb/i2c-ts0</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-18/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-18/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts0</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-18/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-18/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-18/ddimm-0/ocmb/i2c-ts1</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-18/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-18/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts1</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-18/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-18/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-18/ddimm-0/ocmb/i2c-ts2</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-18/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-18/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts2</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>null</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-18/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-19/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-19/ddimm-0/ocmb/i2c-ts0</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-19/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-19/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts0</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-19/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-19/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-19/ddimm-0/ocmb/i2c-ts1</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-19/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-19/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts1</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-19/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-19/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-19/ddimm-0/ocmb/i2c-ts2</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-19/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-19/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts2</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-19/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-20/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-20/ddimm-0/ocmb/i2c-ts0</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-20/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-20/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts0</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-20/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-20/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-20/ddimm-0/ocmb/i2c-ts1</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-20/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-20/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts1</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-20/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-20/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-20/ddimm-0/ocmb/i2c-ts2</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-20/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-20/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts2</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-20/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-21/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-21/ddimm-0/ocmb/i2c-ts0</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-21/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-21/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts0</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-21/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-21/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-21/ddimm-0/ocmb/i2c-ts1</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-21/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-21/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts1</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-21/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-21/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-21/ddimm-0/ocmb/i2c-ts2</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-21/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-21/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts2</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-21/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-22/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-22/ddimm-0/ocmb/i2c-ts0</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-22/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-22/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts0</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-22/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-22/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-22/ddimm-0/ocmb/i2c-ts1</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-22/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-22/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts1</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-22/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-22/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-22/ddimm-0/ocmb/i2c-ts2</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-22/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-22/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts2</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-22/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-23/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-23/ddimm-0/ocmb/i2c-ts0</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-23/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-23/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts0</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-23/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-23/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-23/ddimm-0/ocmb/i2c-ts1</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-23/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-23/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts1</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-23/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-23/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-23/ddimm-0/ocmb/i2c-ts2</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-23/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-23/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts2</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-23/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-24/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-24/ddimm-0/ocmb/i2c-ts0</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-24/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-24/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts0</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-24/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-24/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-24/ddimm-0/ocmb/i2c-ts1</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-24/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-24/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts1</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-24/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-24/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-24/ddimm-0/ocmb/i2c-ts2</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-24/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-24/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts2</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-24/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-25/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-25/ddimm-0/ocmb/i2c-ts0</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-25/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-25/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts0</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-25/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-25/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-25/ddimm-0/ocmb/i2c-ts1</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-25/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-25/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts1</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-25/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-25/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-25/ddimm-0/ocmb/i2c-ts2</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-25/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-25/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts2</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-25/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-26/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-26/ddimm-0/ocmb/i2c-ts0</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-26/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-26/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts0</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-26/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-26/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-26/ddimm-0/ocmb/i2c-ts1</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-26/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-26/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts1</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-26/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-26/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-26/ddimm-0/ocmb/i2c-ts2</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-26/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-26/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts2</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-26/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-27/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-27/ddimm-0/ocmb/i2c-ts0</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-27/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-27/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts0</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-27/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-27/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-27/ddimm-0/ocmb/i2c-ts1</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-27/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-27/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts1</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-27/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-27/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-27/ddimm-0/ocmb/i2c-ts2</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-27/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-27/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts2</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-27/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-28/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-28/ddimm-0/ocmb/i2c-ts0</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-28/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-28/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts0</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-28/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-28/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-28/ddimm-0/ocmb/i2c-ts1</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-28/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-28/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts1</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-28/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-28/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-28/ddimm-0/ocmb/i2c-ts2</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-28/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-28/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts2</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-28/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-29/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-29/ddimm-0/ocmb/i2c-ts0</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-29/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-29/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts0</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-29/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-29/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-29/ddimm-0/ocmb/i2c-ts1</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-29/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-29/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts1</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-29/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-29/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-29/ddimm-0/ocmb/i2c-ts2</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-29/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-29/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts2</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-29/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-30/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-30/ddimm-0/ocmb/i2c-ts0</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-30/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-30/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts0</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-30/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-30/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-30/ddimm-0/ocmb/i2c-ts1</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-30/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-30/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts1</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-30/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-30/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-30/ddimm-0/ocmb/i2c-ts2</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-30/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-30/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts2</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-30/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-31/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-31/ddimm-0/ocmb/i2c-ts0</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-31/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-31/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts0</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-31/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-31/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-31/ddimm-0/ocmb/i2c-ts1</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-31/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-31/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts1</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-31/ddimm-0</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_BUS_ALIAS</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_PURPOSE</id>
+		<default></default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_TYPE</id>
+		<default></default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>ddimm-connector-31/ddimm-0/ocmb/i2c-ocmb-master => ddimm-connector-31/ddimm-0/ocmb/i2c-ts2</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>ddimm-connector-31/ddimm-0/ocmb/</source_path>
+		<source_target>i2c-ocmb-master</source_target>
+		<dest_path>ddimm-connector-31/ddimm-0/ocmb/</dest_path>
+		<dest_target>i2c-ts2</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>FRU_PATH</id>
+		<default>H:/sys-0/node-0/nisqually-0/ddimm-connector-31/ddimm-0</default>
 		</bus_attribute>
 		<bus_attribute>
 			<id>I2C_BUS_ALIAS</id>
@@ -63487,10 +67975,6 @@
 	<attribute>
 		<id>CLASS</id>
 		<default>CHIP</default>
-	</attribute>
-	<attribute>
-		<id>CLOCKSTOP_ON_XSTOP</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>CLOCK_MUX0A_RCS_PLL_INPUT</id>
@@ -79626,10 +84110,6 @@
 	<attribute>
 		<id>CLASS</id>
 		<default>CHIP</default>
-	</attribute>
-	<attribute>
-		<id>CLOCKSTOP_ON_XSTOP</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>CLOCK_MUX0A_RCS_PLL_INPUT</id>
@@ -124604,8 +129084,10 @@
 	<child_id>ocmb</child_id>
 	<child_id>pmic0</child_id>
 	<child_id>pmic1</child_id>
-	<child_id>spd</child_id>
+	<child_id>spdA</child_id>
+	<child_id>spdB</child_id>
 	<child_id>ddr4</child_id>
+	<child_id>ddr5</child_id>
 	<hidden_child_id>dimm_temp_sensor0</hidden_child_id>
 	<hidden_child_id>dimm_temp_sensor1</hidden_child_id>
 	<hidden_child_id>dimm_func_sensor</hidden_child_id>
@@ -124770,10 +129252,13 @@
 	<instance_name>ocmb</instance_name>
 	<position>-1</position>
 	<child_id>omi</child_id>
-	<child_id>mem_port</child_id>
-	<child_id>i2c-ocmb</child_id>
+	<child_id>mem_port0</child_id>
+	<child_id>mem_port1</child_id>
+	<child_id>i2c-ocmb-master</child_id>
+	<child_id>i2c-ocmb-slave</child_id>
 	<child_id>i2c-ts0</child_id>
 	<child_id>i2c-ts1</child_id>
+	<child_id>i2c-ts2</child_id>
 	<attribute>
 		<id>AFFINITY_PATH</id>
 		<default></default>
@@ -124781,10 +129266,6 @@
 	<attribute>
 		<id>CLASS</id>
 		<default>CHIP</default>
-	</attribute>
-	<attribute>
-		<id>CLOCKSTOP_ON_XSTOP</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>EEPROM_VPD_BACKUP_INFO</id>
@@ -124903,12 +129384,48 @@
 		<default>5</default>
 	</attribute>
 	<attribute>
+		<id>OMI_CHANNEL_LENGTH</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>OMI_RX_HORIZ_OFFSET</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>OMI_RX_LANES</id>
 		<default>X8</default>
 	</attribute>
 	<attribute>
+		<id>OMI_RX_LTEG</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>OMI_RX_LTEZ</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>OMI_RX_PHASE_STEP</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>OMI_RX_VERT_OFFSET</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>OMI_TX_LANES</id>
 		<default>X8</default>
+	</attribute>
+	<attribute>
+		<id>OMI_TX_POST</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>OMI_TX_PRE1</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>OMI_TX_PRE2</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -125015,10 +129532,10 @@
 	</attribute>
 </targetInstance>
 <targetInstance>
-	<id>mem_port</id>
+	<id>mem_port0</id>
 	<type>unit-mem_port</type>
 	<is_root>false</is_root>
-	<instance_name>mem_port</instance_name>
+	<instance_name>mem_port0</instance_name>
 	<position>-1</position>
 	<attribute>
 		<id>AFFINITY_PATH</id>
@@ -125026,7 +129543,7 @@
 	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
-		<default>DDR4</default>
+		<default>DDR5</default>
 	</attribute>
 	<attribute>
 		<id>CHIP_UNIT</id>
@@ -125070,10 +129587,116 @@
 	</attribute>
 </targetInstance>
 <targetInstance>
-	<id>i2c-ocmb</id>
+	<id>mem_port1</id>
+	<type>unit-mem_port</type>
+	<is_root>false</is_root>
+	<instance_name>mem_port1</instance_name>
+	<position>-1</position>
+	<attribute>
+		<id>AFFINITY_PATH</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>BUS_TYPE</id>
+		<default>DDR5</default>
+	</attribute>
+	<attribute>
+		<id>CHIP_UNIT</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>UNIT</default>
+	</attribute>
+	<attribute>
+		<id>DIRECTION</id>
+		<default>OUT</default>
+	</attribute>
+	<attribute>
+		<id>EXP_SAFEMODE_MEM_THROTTLED_N_COMMANDS_PER_PORT</id>
+		<default>32</default>
+	</attribute>
+	<attribute>
+		<id>FAPI_NAME</id>
+		<default>unknown</default>
+	</attribute>
+	<attribute>
+		<id>MODEL</id>
+		<default>POWER10</default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>PHYS_PATH</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>MEM_PORT</default>
+	</attribute>
+</targetInstance>
+<targetInstance>
+	<id>i2c-ocmb-master</id>
+	<type>unit-i2c-master</type>
+	<is_root>false</is_root>
+	<instance_name>i2c-ocmb-master</instance_name>
+	<position>-1</position>
+	<attribute>
+		<id>BUS_TYPE</id>
+		<default>I2C</default>
+	</attribute>
+	<attribute>
+		<id>CHIP_UNIT</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>UNIT</default>
+	</attribute>
+	<attribute>
+		<id>DIRECTION</id>
+		<default>OUT</default>
+	</attribute>
+	<attribute>
+		<id>I2C_CONNECTION_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>I2C_ENGINE</id>
+		<default>0x00</default>
+	</attribute>
+	<attribute>
+		<id>I2C_PORT</id>
+		<default>0x00</default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>REG_BASE_ADDRESS</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>REG_OFFSET</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetInstance>
+<targetInstance>
+	<id>i2c-ocmb-slave</id>
 	<type>unit-i2c-slave</type>
 	<is_root>false</is_root>
-	<instance_name>i2c-ocmb</instance_name>
+	<instance_name>i2c-ocmb-slave</instance_name>
 	<position>-1</position>
 	<attribute>
 		<id>BUS_TYPE</id>
@@ -125172,6 +129795,45 @@
 	<attribute>
 		<id>I2C_ADDRESS</id>
 		<default>0x32</default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>VPD_SIZE</id>
+		<default>NA</default>
+	</attribute>
+</targetInstance>
+<targetInstance>
+	<id>i2c-ts2</id>
+	<type>unit-i2c-slave</type>
+	<is_root>false</is_root>
+	<instance_name>i2c-ts2</instance_name>
+	<position>-1</position>
+	<attribute>
+		<id>BUS_TYPE</id>
+		<default>I2C</default>
+	</attribute>
+	<attribute>
+		<id>CHIP_UNIT</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>UNIT</default>
+	</attribute>
+	<attribute>
+		<id>DIRECTION</id>
+		<default>IN</default>
+	</attribute>
+	<attribute>
+		<id>I2C_ADDRESS</id>
+		<default>0x34</default>
 	</attribute>
 	<attribute>
 		<id>MRW_TYPE</id>
@@ -125391,10 +130053,58 @@
 	</attribute>
 </targetInstance>
 <targetInstance>
-	<id>spd</id>
+	<id>spdA</id>
 	<type>chip-spd-device</type>
 	<is_root>false</is_root>
-	<instance_name>spd</instance_name>
+	<instance_name>spdA</instance_name>
+	<position>-1</position>
+	<child_id>i2c-slave</child_id>
+	<attribute>
+		<id>BYTE_ADDRESS_OFFSET</id>
+		<default>0x02</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>CHIP</default>
+	</attribute>
+	<attribute>
+		<id>MEMORY_SIZE_IN_KB</id>
+		<default>0x04</default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>SPD</default>
+	</attribute>
+	<attribute>
+		<id>POSITION</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>RU_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>VPD_TYPE</id>
+		<default>SPD</default>
+	</attribute>
+	<attribute>
+		<id>WRITE_CYCLE_TIME</id>
+		<default>0x05</default>
+	</attribute>
+	<attribute>
+		<id>WRITE_PAGE_SIZE</id>
+		<default>0x20</default>
+	</attribute>
+</targetInstance>
+<targetInstance>
+	<id>spdB</id>
+	<type>chip-spd-device</type>
+	<is_root>false</is_root>
+	<instance_name>spdB</instance_name>
 	<position>-1</position>
 	<child_id>i2c-slave</child_id>
 	<attribute>
@@ -125451,6 +130161,57 @@
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>DDR4</default>
+	</attribute>
+	<attribute>
+		<id>CHIP_UNIT</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>UNIT</default>
+	</attribute>
+	<attribute>
+		<id>DIRECTION</id>
+		<default>IN</default>
+	</attribute>
+	<attribute>
+		<id>FAPI_NAME</id>
+		<default>unknown</default>
+	</attribute>
+	<attribute>
+		<id>MODEL</id>
+		<default>JEDEC</default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>PHYS_PATH</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetInstance>
+<targetInstance>
+	<id>ddr5</id>
+	<type>unit-ddr5-jedec</type>
+	<is_root>false</is_root>
+	<instance_name>ddr5</instance_name>
+	<position>-1</position>
+	<attribute>
+		<id>AFFINITY_PATH</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>BUS_TYPE</id>
+		<default>DDR5</default>
 	</attribute>
 	<attribute>
 		<id>CHIP_UNIT</id>


### PR DESCRIPTION
1.) Rainier 2U MRW support for Odyssey

2.) Fixed defect PE00FRQH update to EXTERNAL_VRM_STEPSIZE initializer to match array size