### PR TITLE
Explicitly disable DDR5 support

### DIFF
--- a/Rainier-2U-MRW.xml
+++ b/Rainier-2U-MRW.xml
@@ -42494,7 +42494,7 @@
 	</attribute>
 	<attribute>
 		<id>MSS_MRW_ALLOW_DDR5</id>
-		<default>ALLOW</default>
+		<default>REJECT</default>
 	</attribute>
 	<attribute>
 		<id>MSS_MRW_ALLOW_UNSUPPORTED_RCW</id>

--- a/Rainier-4U-MRW.xml
+++ b/Rainier-4U-MRW.xml
@@ -50562,7 +50562,7 @@
 	</attribute>
 	<attribute>
 		<id>MSS_MRW_ALLOW_DDR5</id>
-		<default>ALLOW</default>
+		<default>REJECT</default>
 	</attribute>
 	<attribute>
 		<id>MSS_MRW_ALLOW_UNSUPPORTED_RCW</id>


### PR DESCRIPTION
There is no DDR5 support in FW1050