### PR TITLE
410083 : Update EXTERNAL_VRM_STEPSIZE initializer to match array size

### DIFF
--- a/Rainier-2U-MRW.xml
+++ b/Rainier-2U-MRW.xml
@@ -68078,7 +68078,7 @@
 	</attribute>
 	<attribute>
 		<id>EXTERNAL_VRM_STEPSIZE</id>
-		<default>0x00</default>
+		<default>0x00,0x00,0x00,0x00</default>
 	</attribute>
 	<attribute>
 		<id>FABRIC_CHIP_ID</id>
@@ -84213,7 +84213,7 @@
 	</attribute>
 	<attribute>
 		<id>EXTERNAL_VRM_STEPSIZE</id>
-		<default>0x00</default>
+		<default>0x00,0x00,0x00,0x00</default>
 	</attribute>
 	<attribute>
 		<id>FABRIC_CHIP_ID</id>

--- a/Rainier-4U-MRW.xml
+++ b/Rainier-4U-MRW.xml
@@ -83854,7 +83854,7 @@
 	</attribute>
 	<attribute>
 		<id>EXTERNAL_VRM_STEPSIZE</id>
-		<default>0x00</default>
+		<default>0x00,0x00,0x00,0x00</default>
 	</attribute>
 	<attribute>
 		<id>FABRIC_CHIP_ID</id>
@@ -99993,7 +99993,7 @@
 	</attribute>
 	<attribute>
 		<id>EXTERNAL_VRM_STEPSIZE</id>
-		<default>0x00</default>
+		<default>0x00,0x00,0x00,0x00</default>
 	</attribute>
 	<attribute>
 		<id>FABRIC_CHIP_ID</id>


### PR DESCRIPTION
Attribute EXTERNAL_VRM_STEPSIZE needs to be defined as an array of 4 values (0x00,0x00,0x00,0x00) instead of a single value.