### PR TITLE
Fix CHIP_UNIT for memport1 to be 1

### DIFF
--- a/Rainier-2U-MRW.xml
+++ b/Rainier-2U-MRW.xml
@@ -129602,7 +129602,7 @@
 	</attribute>
 	<attribute>
 		<id>CHIP_UNIT</id>
-		<default>0</default>
+		<default>1</default>
 	</attribute>
 	<attribute>
 		<id>CLASS</id>


### PR DESCRIPTION
Missed an update when adding the second mem_port target for Odyssey.