### PR TITLE
Adding array of min pcap values for FW1050 branch per PE00LGNS

### DIFF
--- a/Rainier-2U-MRW.xml
+++ b/Rainier-2U-MRW.xml
@@ -42224,6 +42224,10 @@
 		<id>HW543822_WAR_MODE</id>
 		<default>NONE</default>
 	</attribute>
+	<attribute>	
+ 		<id>INDEX_MIN_POWER_CAP_WATTS</id>	
+ 		<default>1060,750,1060,750,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0</default>	
+ 	</attribute>	
 	<attribute>
 		<id>INDEX_N_BULK_POWER_LIMIT_WATTS</id>
 		<default>1880,930,1880,930,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0</default>

--- a/Rainier-4U-MRW.xml
+++ b/Rainier-4U-MRW.xml
@@ -50292,6 +50292,10 @@
 		<id>HW543822_WAR_MODE</id>
 		<default>NONE</default>
 	</attribute>
+	<attribute>	
+ 		<id>INDEX_MIN_POWER_CAP_WATTS</id>	
+ 		<default>780,750,1030,840,870,2000,780,750,1030,840,870,2000,0,0,0,0,0,0,0,0,0,0,0,0</default>	
+ 	</attribute>	
 	<attribute>
 		<id>INDEX_N_BULK_POWER_LIMIT_WATTS</id>
 		<default>1120,930,2260,1880,1500,3020,1120,930,2260,1880,1500,3020,0,0,0,0,0,0,0,0,0,0,0,0</default>


### PR DESCRIPTION
This commit updates the MRW for Rainier 2U and 4U to assign unique values to this new attribute for each of the PSU types, input voltage and number of PSUs present.

I expect the main review to come from Sheldon for this PR. This is the commit for the FW1050 branch. There will be one last commit to update the master branch as well. 