### PR TITLE
Adding array of min pcap values for master branch per PE00LGNS

### DIFF
--- a/Rainier-2U-MRW.xml
+++ b/Rainier-2U-MRW.xml
@@ -44079,6 +44079,10 @@
 		<id>HW543822_WAR_MODE</id>
 		<default>NONE</default>
 	</attribute>
+	<attribute>	
+  		<id>INDEX_MIN_POWER_CAP_WATTS</id>	
+  		<default>1060,750,1060,750,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0</default>	
+  	</attribute>	
 	<attribute>
 		<id>INDEX_N_BULK_POWER_LIMIT_WATTS</id>
 		<default>1880,930,1880,930,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0</default>


### PR DESCRIPTION
This commit updates the MRW for Rainier 2U and 4U to assign unique values to this new attribute for each of the PSU types, input voltage and number of PSUs present.

I expect the main review to come from Sheldon for this PR. This is the commit for the Master branch. This should be the last commit. 